### PR TITLE
enable sourcemap output on build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -68,7 +68,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "aot": true,


### PR DESCRIPTION
[According to Sentry](https://docs.sentry.io/platforms/javascript/sourcemaps/#hosting-source-map-files) this should work. No real concern about exposing source (it is an open-source project after all) or caching, since Angular includes each build's hash in its URL.