### PR TITLE
Add more e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
   - npm install
 script:
   - npm run build-themes
-  - ng e2e --protractor-config=e2e/protractor-ci.conf.js
-  - ng build
+  - ng e2e --protractor-config=e2e/protractor-ci.conf.js --prod
   - ng build --prod
   - cp dist/index.html dist/404.html
 deploy:

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,6 @@
-import { AppPage } from './app.po';
+import {AppPage} from './app.po';
 
-describe('workspace-project App', () => {
+describe('avrae frontpage', () => {
   let page: AppPage;
 
   beforeEach(() => {

--- a/e2e/src/cheatsheets/aliasing.e2e-spec.ts
+++ b/e2e/src/cheatsheets/aliasing.e2e-spec.ts
@@ -1,0 +1,12 @@
+import {browser, by, element} from 'protractor';
+
+describe('avrae cheatsheet: aliasing', () => {
+
+  beforeAll(() => {
+    browser.get('/cheatsheets/aliasing');
+  });
+
+  it('should display a header', () => {
+    expect(element(by.css('h1')).getText()).toEqual('Aliasing');
+  });
+});

--- a/e2e/src/cheatsheets/cheatsheets.e2e-spec.ts
+++ b/e2e/src/cheatsheets/cheatsheets.e2e-spec.ts
@@ -1,0 +1,17 @@
+import {browser, by, element} from 'protractor';
+
+describe('avrae cheatsheets home', () => {
+
+  beforeAll(() => {
+    browser.get('/cheatsheets');
+  });
+
+  it('should display a header', () => {
+    expect(element(by.css('h1')).getText()).toEqual('Cheatsheets');
+  });
+
+  it('should show some cheatsheets', () => {
+    const cheatsheets = element.all(by.css('mat-card.cheatsheet'));
+    expect(cheatsheets.count()).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/commands.e2e-spec.ts
+++ b/e2e/src/commands.e2e-spec.ts
@@ -1,0 +1,35 @@
+import {browser, by, element} from 'protractor';
+
+describe('avrae commands page', () => {
+  let sidenavButtons;
+  let renderedModules;
+
+  beforeAll(() => {
+    browser.get('/commands');
+    sidenavButtons = element.all(by.css('a.mat-list-item'));
+    renderedModules = element.all(by.css('mat-card.container'));
+  });
+
+  it('should display a header', () => {
+    expect(element(by.css('h1')).getText()).toEqual('Command List');
+  });
+
+  it('should populate the sidebar', () => {
+    expect(sidenavButtons.count()).toBeGreaterThan(0);
+  });
+
+  it('should show some modules', () => {
+    expect(renderedModules.count()).toBeGreaterThan(0);
+  });
+
+  it('should have the same number of rendered modules and sidebar navs', () => {
+    expect(renderedModules.count()).toEqual(sidenavButtons.count());
+  });
+
+  it('should show some commands in each module', () => {
+    renderedModules.each(moduleElement => {
+      const moduleCommands = moduleElement.all(by.css('mat-expansion-panel'));
+      expect(moduleCommands.count()).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Also removed `ng build` from the CI script, since we just `ng build --prod` right after.

Runs `ng e2e --prod` to hit the API for `/commands` and `/cheatsheets`.