### PR TITLE
WEB-031: Lazy render of some components

### DIFF
--- a/src/app/dashboard/homebrew/items/pack-detail/item-detail/item-detail.component.html
+++ b/src/app/dashboard/homebrew/items/pack-detail/item-detail/item-detail.component.html
@@ -8,38 +8,40 @@
     <mat-panel-description markdown [data]="item.meta.split('\n')[0]">
     </mat-panel-description>
   </mat-expansion-panel-header>
-  <div class="form-container">
-    <div fxLayout="row" fxLayoutGap="4px">
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Name" (change)="emitChange()" [(ngModel)]="item.name">
+  <ng-template matExpansionPanelContent>
+    <div class="form-container">
+      <div fxLayout="row" fxLayoutGap="4px">
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Name" (change)="emitChange()" [(ngModel)]="item.name">
+        </mat-form-field>
+        <mat-form-field fxFlex *ngIf="item.image != undefined">
+          <input matInput placeholder="Image URL" (change)="emitChange()" [(ngModel)]="item.image">
+        </mat-form-field>
+      </div>
+      <mat-form-field>
+        <textarea matInput placeholder="Meta" rows="3" (change)="emitChange()" [(ngModel)]="item.meta"></textarea>
       </mat-form-field>
-      <mat-form-field fxFlex *ngIf="item.image != undefined">
-        <input matInput placeholder="Image URL" (change)="emitChange()" [(ngModel)]="item.image">
+      <mat-form-field>
+        <textarea matInput placeholder="Description" rows="7" (change)="emitChange()" [(ngModel)]="item.desc"></textarea>
       </mat-form-field>
     </div>
-    <mat-form-field>
-      <textarea matInput placeholder="Meta" rows="3" (change)="emitChange()" [(ngModel)]="item.meta"></textarea>
-    </mat-form-field>
-    <mat-form-field>
-      <textarea matInput placeholder="Description" rows="7" (change)="emitChange()" [(ngModel)]="item.desc"></textarea>
-    </mat-form-field>
-  </div>
-  <div class="actions" fxLayout="row">
-    <span fxFlex *ngIf="item.image === undefined">
-      <button mat-icon-button matTooltip="Add image" (click)="item.image=''; emitChange()">
-        <mat-icon aria-label="Add image">add_photo_alternate</mat-icon>
-      </button>
-    </span>
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Export to JSON" (click)="beginJSONExport()">
-        <mat-icon aria-label="Export to JSON">vertical_align_top</mat-icon>
-      </button>
-    </span>
-    <span fxFlex="grow"></span>
-    <span fxFlex>
-      <button mat-icon-button color="warn" (click)="delete.emit()">
-        <mat-icon aria-label="Delete">delete</mat-icon>
-      </button>
-    </span>
-  </div>
+    <div class="actions" fxLayout="row">
+      <span fxFlex *ngIf="item.image === undefined">
+        <button mat-icon-button matTooltip="Add image" (click)="item.image=''; emitChange()">
+          <mat-icon aria-label="Add image">add_photo_alternate</mat-icon>
+        </button>
+      </span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Export to JSON" (click)="beginJSONExport()">
+          <mat-icon aria-label="Export to JSON">vertical_align_top</mat-icon>
+        </button>
+      </span>
+      <span fxFlex="grow"></span>
+      <span fxFlex>
+        <button mat-icon-button color="warn" (click)="delete.emit()">
+          <mat-icon aria-label="Delete">delete</mat-icon>
+        </button>
+      </span>
+    </div>
+  </ng-template>
 </mat-expansion-panel>

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.scss
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.scss
@@ -1,6 +1,8 @@
 @import "../../../../_variables.scss";
 @import "../_variables.scss";
 
+$viewport-height: calc(100vh - #{$navbar-height + $footer-height + $pack-toolbar-height + ($container-margin*2)});
+
 .pack-toolbar {
   height: $pack-toolbar-height;
 }
@@ -10,7 +12,12 @@
 }
 
 .item-list {
-  max-height: calc(100vh - #{$navbar-height + $footer-height + $pack-toolbar-height + ($container-margin*2)});
+  max-height: $viewport-height;
+  overflow-y: auto;
+}
+
+.item-preview {
+  max-height: $viewport-height;
   overflow-y: auto;
 }
 

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
@@ -8,130 +8,131 @@
     </mat-panel-title>
     <avr-spell-panel-description [level]="spell.level" [school]="spell.school"></avr-spell-panel-description>
   </mat-expansion-panel-header>
+  <ng-template matExpansionPanelContent>
+    <div class="form-container">
+      <!-- NAME AND IMAGE -->
+      <div fxLayout="row" fxLayoutGap="4px">
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Name" (change)="emitChange()" [(ngModel)]="spell.name">
+        </mat-form-field>
+        <mat-form-field fxFlex *ngIf="spell.image != undefined">
+          <input matInput placeholder="Image URL" (change)="emitChange()" [(ngModel)]="spell.image">
+        </mat-form-field>
+      </div>
 
-  <div class="form-container">
-    <!-- NAME AND IMAGE -->
-    <div fxLayout="row" fxLayoutGap="4px">
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Name" (change)="emitChange()" [(ngModel)]="spell.name">
+      <!-- LEVEL, SCHOOL, RITUAL -->
+      <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
+        <mat-form-field fxFlex>
+          <mat-label>Level</mat-label>
+          <mat-select [(value)]="spell.level" (selectionChange)="emitChange()">
+            <mat-option [value]="0">Cantrip</mat-option>
+            <mat-option [value]="1">1st Level</mat-option>
+            <mat-option [value]="2">2nd Level</mat-option>
+            <mat-option [value]="3">3rd Level</mat-option>
+            <mat-option [value]="4">4th Level</mat-option>
+            <mat-option [value]="5">5th Level</mat-option>
+            <mat-option [value]="6">6th Level</mat-option>
+            <mat-option [value]="7">7th Level</mat-option>
+            <mat-option [value]="8">8th Level</mat-option>
+            <mat-option [value]="9">9th Level</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field fxFlex>
+          <mat-label>School</mat-label>
+          <mat-select [(value)]="spell.school" (selectionChange)="emitChange()">
+            <mat-option value="A">Abjuration</mat-option>
+            <mat-option value="C">Conjuration</mat-option>
+            <mat-option value="D">Divination</mat-option>
+            <mat-option value="E">Enchantment</mat-option>
+            <mat-option value="V">Evocation</mat-option>
+            <mat-option value="I">Illusion</mat-option>
+            <mat-option value="N">Necromancy</mat-option>
+            <mat-option value="T">Transmutation</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.ritual" (change)="emitChange()">Ritual</mat-checkbox>
+      </div>
+
+      <!-- TIME, RANGE, DURATION -->
+      <div fxLayout="row" fxLayoutGap="6px">
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Casting Time" (change)="emitChange()" [(ngModel)]="spell.casttime">
+        </mat-form-field>
+
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Range" (change)="emitChange()" [(ngModel)]="spell.range">
+        </mat-form-field>
+
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Duration" (change)="emitChange()" [(ngModel)]="spell.duration">
+        </mat-form-field>
+      </div>
+
+      <!-- COMPONENTS AND CONCENTRATION -->
+      <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
+        <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.components.verbal" (change)="emitChange()">
+          Verbal
+        </mat-checkbox>
+        <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.components.somatic" (change)="emitChange()">
+          Somatic
+        </mat-checkbox>
+        <mat-form-field fxFlex>
+          <input matInput placeholder="Material" (change)="emitChange()" [(ngModel)]="spell.components.material">
+        </mat-form-field>
+        <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.concentration" (change)="emitChange()">
+          Concentration
+        </mat-checkbox>
+      </div>
+
+      <!-- DESCRIPTION -->
+      <mat-form-field>
+        <textarea matInput placeholder="Description" rows="7" (change)="emitChange()"
+                  [(ngModel)]="spell.description"></textarea>
       </mat-form-field>
-      <mat-form-field fxFlex *ngIf="spell.image != undefined">
-        <input matInput placeholder="Image URL" (change)="emitChange()" [(ngModel)]="spell.image">
+
+      <!-- HIGHER LEVELS -->
+      <mat-form-field>
+        <textarea matInput placeholder="At Higher Levels" rows="3" (change)="emitChange()"
+                  [(ngModel)]="spell.higherlevels"></textarea>
       </mat-form-field>
+
+      <!-- CLASSES AND SUBCLASSES -->
+      <div fxLayout="row" fxLayoutGap="6px">
+        <mat-form-field fxFlex matTooltip="Separate classes with commas.">
+          <input matInput placeholder="Classes" (change)="emitChange()" [(ngModel)]="spell.classes">
+        </mat-form-field>
+
+        <mat-form-field fxFlex matTooltip="Separate subclasses with commas.">
+          <input matInput placeholder="Subclasses" (change)="emitChange()" [(ngModel)]="spell.subclasses">
+        </mat-form-field>
+      </div>
     </div>
 
-    <!-- LEVEL, SCHOOL, RITUAL -->
-    <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
-      <mat-form-field fxFlex>
-        <mat-label>Level</mat-label>
-        <mat-select [(value)]="spell.level" (selectionChange)="emitChange()">
-          <mat-option [value]="0">Cantrip</mat-option>
-          <mat-option [value]="1">1st Level</mat-option>
-          <mat-option [value]="2">2nd Level</mat-option>
-          <mat-option [value]="3">3rd Level</mat-option>
-          <mat-option [value]="4">4th Level</mat-option>
-          <mat-option [value]="5">5th Level</mat-option>
-          <mat-option [value]="6">6th Level</mat-option>
-          <mat-option [value]="7">7th Level</mat-option>
-          <mat-option [value]="8">8th Level</mat-option>
-          <mat-option [value]="9">9th Level</mat-option>
-        </mat-select>
-      </mat-form-field>
-
-      <mat-form-field fxFlex>
-        <mat-label>School</mat-label>
-        <mat-select [(value)]="spell.school" (selectionChange)="emitChange()">
-          <mat-option value="A">Abjuration</mat-option>
-          <mat-option value="C">Conjuration</mat-option>
-          <mat-option value="D">Divination</mat-option>
-          <mat-option value="E">Enchantment</mat-option>
-          <mat-option value="V">Evocation</mat-option>
-          <mat-option value="I">Illusion</mat-option>
-          <mat-option value="N">Necromancy</mat-option>
-          <mat-option value="T">Transmutation</mat-option>
-        </mat-select>
-      </mat-form-field>
-
-      <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.ritual" (change)="emitChange()">Ritual</mat-checkbox>
+    <!-- ACTION BUTTONS -->
+    <div class="actions" fxLayout="row">
+      <span fxFlex *ngIf="spell.image === undefined">
+        <button mat-icon-button matTooltip="Add image" (click)="spell.image=''; emitChange()">
+          <mat-icon aria-label="Add image">add_photo_alternate</mat-icon>
+        </button>
+      </span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Export to JSON" (click)="beginJSONExport()">
+          <mat-icon aria-label="Export to JSON">vertical_align_top</mat-icon>
+        </button>
+      </span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Edit Automation" (click)="moveToEditor.emit()">
+          <mat-icon aria-label="Edit Automation">build</mat-icon>
+        </button>
+      </span>
+      <span fxFlex="grow"></span>
+      <span fxFlex>
+        <button mat-icon-button color="warn" (click)="delete.emit()">
+          <mat-icon aria-label="Delete">delete</mat-icon>
+        </button>
+      </span>
     </div>
-
-    <!-- TIME, RANGE, DURATION -->
-    <div fxLayout="row" fxLayoutGap="6px">
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Casting Time" (change)="emitChange()" [(ngModel)]="spell.casttime">
-      </mat-form-field>
-
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Range" (change)="emitChange()" [(ngModel)]="spell.range">
-      </mat-form-field>
-
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Duration" (change)="emitChange()" [(ngModel)]="spell.duration">
-      </mat-form-field>
-    </div>
-
-    <!-- COMPONENTS AND CONCENTRATION -->
-    <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
-      <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.components.verbal" (change)="emitChange()">
-        Verbal
-      </mat-checkbox>
-      <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.components.somatic" (change)="emitChange()">
-        Somatic
-      </mat-checkbox>
-      <mat-form-field fxFlex>
-        <input matInput placeholder="Material" (change)="emitChange()" [(ngModel)]="spell.components.material">
-      </mat-form-field>
-      <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.concentration" (change)="emitChange()">
-        Concentration
-      </mat-checkbox>
-    </div>
-
-    <!-- DESCRIPTION -->
-    <mat-form-field>
-      <textarea matInput placeholder="Description" rows="7" (change)="emitChange()"
-                [(ngModel)]="spell.description"></textarea>
-    </mat-form-field>
-
-    <!-- HIGHER LEVELS -->
-    <mat-form-field>
-      <textarea matInput placeholder="At Higher Levels" rows="3" (change)="emitChange()"
-                [(ngModel)]="spell.higherlevels"></textarea>
-    </mat-form-field>
-
-    <!-- CLASSES AND SUBCLASSES -->
-    <div fxLayout="row" fxLayoutGap="6px">
-      <mat-form-field fxFlex matTooltip="Separate classes with commas.">
-        <input matInput placeholder="Classes" (change)="emitChange()" [(ngModel)]="spell.classes">
-      </mat-form-field>
-
-      <mat-form-field fxFlex matTooltip="Separate subclasses with commas.">
-        <input matInput placeholder="Subclasses" (change)="emitChange()" [(ngModel)]="spell.subclasses">
-      </mat-form-field>
-    </div>
-  </div>
-
-  <!-- ACTION BUTTONS -->
-  <div class="actions" fxLayout="row">
-    <span fxFlex *ngIf="spell.image === undefined">
-      <button mat-icon-button matTooltip="Add image" (click)="spell.image=''; emitChange()">
-        <mat-icon aria-label="Add image">add_photo_alternate</mat-icon>
-      </button>
-    </span>
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Export to JSON" (click)="beginJSONExport()">
-        <mat-icon aria-label="Export to JSON">vertical_align_top</mat-icon>
-      </button>
-    </span>
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Edit Automation" (click)="moveToEditor.emit()">
-        <mat-icon aria-label="Edit Automation">build</mat-icon>
-      </button>
-    </span>
-    <span fxFlex="grow"></span>
-    <span fxFlex>
-      <button mat-icon-button color="warn" (click)="delete.emit()">
-        <mat-icon aria-label="Delete">delete</mat-icon>
-      </button>
-    </span>
-  </div>
+  </ng-template>
 </mat-expansion-panel>

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-editor/effect-editor/effect-editor.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-editor/effect-editor/effect-editor.component.html
@@ -6,58 +6,58 @@
       </div>
     </mat-panel-title>
   </mat-expansion-panel-header>
+  <ng-template matExpansionPanelContent>
+    <div [ngSwitch]="effect.type">
+      <avr-target-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                         *ngSwitchCase="'target'"></avr-target-effect>
 
-  <div [ngSwitch]="effect.type">
-    <avr-target-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                       *ngSwitchCase="'target'"></avr-target-effect>
+      <avr-attack-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                         *ngSwitchCase="'attack'"></avr-attack-effect>
 
-    <avr-attack-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                       *ngSwitchCase="'attack'"></avr-attack-effect>
+      <avr-save-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                       *ngSwitchCase="'save'"></avr-save-effect>
 
-    <avr-save-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                     *ngSwitchCase="'save'"></avr-save-effect>
+      <avr-damage-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                         *ngSwitchCase="'damage'"></avr-damage-effect>
 
-    <avr-damage-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                       *ngSwitchCase="'damage'"></avr-damage-effect>
+      <avr-temphp-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                         *ngSwitchCase="'temphp'"></avr-temphp-effect>
 
-    <avr-temphp-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                       *ngSwitchCase="'temphp'"></avr-temphp-effect>
+      <avr-ieffect-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                          *ngSwitchCase="'ieffect'"></avr-ieffect-effect>
 
-    <avr-ieffect-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                        *ngSwitchCase="'ieffect'"></avr-ieffect-effect>
+      <avr-roll-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                       *ngSwitchCase="'roll'"></avr-roll-effect>
 
-    <avr-roll-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                     *ngSwitchCase="'roll'"></avr-roll-effect>
+      <avr-text-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                       *ngSwitchCase="'text'"></avr-text-effect>
 
-    <avr-text-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
-                     *ngSwitchCase="'text'"></avr-text-effect>
-
-    <div *ngSwitchDefault>
-      You should not see this text. If you do, that's a bug! Please report that {{effect.type}} is not handled on the
-      dev server!
+      <div *ngSwitchDefault>
+        You should not see this text. If you do, that's a bug! Please report that {{effect.type}} is not handled on the
+        dev server!
+      </div>
     </div>
-  </div>
 
-  <avr-effect-editor [parent]="effect.meta" [spell]="spell" (changed)="changed.emit()"></avr-effect-editor>
+    <avr-effect-editor [parent]="effect.meta" [spell]="spell" (changed)="changed.emit()"></avr-effect-editor>
 
-  <!-- ACTION BUTTONS -->
-  <div class="actions" fxLayout="row">
-    <span fxFlex *ngIf="!isFirst">
-      <button mat-icon-button matTooltip="Move Up" (click)="moveUp(effect)">
-        <mat-icon aria-label="Move Up">arrow_upward</mat-icon>
-      </button>
-    </span>
-    <span fxFlex *ngIf="!isLast">
-      <button mat-icon-button matTooltip="Move Down" (click)="moveDown(effect)">
-        <mat-icon aria-label="Move Down">arrow_downward</mat-icon>
-      </button>
-    </span>
-    <span fxFlex="grow"></span>
-    <span fxFlex>
-      <button mat-icon-button color="warn" (click)="delete(effect)">
-        <mat-icon aria-label="Delete">delete</mat-icon>
-      </button>
-    </span>
-  </div>
-
+    <!-- ACTION BUTTONS -->
+    <div class="actions" fxLayout="row">
+      <span fxFlex *ngIf="!isFirst">
+        <button mat-icon-button matTooltip="Move Up" (click)="moveUp(effect)">
+          <mat-icon aria-label="Move Up">arrow_upward</mat-icon>
+        </button>
+      </span>
+      <span fxFlex *ngIf="!isLast">
+        <button mat-icon-button matTooltip="Move Down" (click)="moveDown(effect)">
+          <mat-icon aria-label="Move Down">arrow_downward</mat-icon>
+        </button>
+      </span>
+      <span fxFlex="grow"></span>
+      <span fxFlex>
+        <button mat-icon-button color="warn" (click)="delete(effect)">
+          <mat-icon aria-label="Delete">delete</mat-icon>
+        </button>
+      </span>
+    </div>
+  </ng-template>
 </mat-expansion-panel>

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.scss
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.scss
@@ -1,17 +1,25 @@
 @import "../../../../../_variables.scss";
 @import "../../_variables.scss";
 
+$new-spell-card-height: 48px;
+$viewport-height: calc(100vh - #{$navbar-height + $footer-height + $tome-toolbar-height + $tome-tabs-height + ($container-margin*2)});
+
 .container {
   margin: $container-margin;
 }
 
 .spell-list {
-  max-height: calc(100vh - #{$navbar-height + $footer-height + $tome-toolbar-height + $tome-tabs-height + ($container-margin*2)});
+  max-height: $viewport-height;
+  overflow-y: auto;
+}
+
+.spell-preview {
+  max-height: $viewport-height;
   overflow-y: auto;
 }
 
 .new-spell-card {
-  height: 48px;
+  height: $new-spell-card-height;
   padding: 0 24px;
 }
 


### PR DESCRIPTION
Closes #61

Unfortunately, virtual scrolling doesn't seem to work very well with Angular Material expansion panels (see: https://github.com/angular/components/issues/13696, https://github.com/angular/components/issues/13697 - the posted workaround causes severe jumping while scrolling, and forgets the state of panels that scroll offscreen).

This implementation instead applies lazy rendering to the content inside the expansion panels (i.e. components are only added to the DOM when a panel is opened), reducing the amount of stuff rendered and reducing animation lag considerably.