### PR TITLE
Add page to look up gvars

### DIFF
--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -30,6 +30,12 @@ mat-expansion-panel-header {
   font-size: 90%;
 }
 
+.icon-in-panel {
+  font-size: 16px;
+  height: 16px;
+  padding-left: 4px;
+}
+
 @media only screen and (max-width: 840px) {
   .sidenav{
     width:150px;

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -28,7 +28,7 @@
         <div class="nav-panel-body">
           <a mat-list-item routerLink="/dashboard/homebrew/items">Items</a>
           <a mat-list-item routerLink="/dashboard/homebrew/spells">Spells</a>
-          <a mat-list-item href="https://critterdb.com/#/index" target="_blank">Creatures
+          <a mat-list-item href="https://critterdb.com/#/index" target="_blank" rel="noopener noreferrer">Creatures
             <mat-icon class="icon-in-panel">launch</mat-icon>
           </a>
         </div>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -6,9 +6,18 @@
     fixedTopGap="56px">
     <mat-nav-list>
       <a mat-list-item [routerLink]="['characters']">Characters</a>
-      <a mat-list-item [routerLink]="['aliases']">Customization</a>
-      <a mat-list-item [routerLink]="['gvars']">Global Variables</a>
-      <div class="spacer"></div>
+
+      <mat-expansion-panel class="mat-elevation-z0">
+        <mat-expansion-panel-header>
+          <mat-panel-title class="nav-panel">
+            Customization
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <div class="nav-panel-body">
+          <a mat-list-item [routerLink]="['aliases']">Your Customizations</a>
+          <a mat-list-item [routerLink]="['gvars']">Global Variables</a>
+        </div>
+      </mat-expansion-panel>
 
       <mat-expansion-panel class="mat-elevation-z0">
         <mat-expansion-panel-header>
@@ -19,6 +28,9 @@
         <div class="nav-panel-body">
           <a mat-list-item routerLink="/dashboard/homebrew/items">Items</a>
           <a mat-list-item routerLink="/dashboard/homebrew/spells">Spells</a>
+          <a mat-list-item href="https://critterdb.com/#/index" target="_blank">Creatures
+            <mat-icon class="icon-in-panel">launch</mat-icon>
+          </a>
         </div>
       </mat-expansion-panel>
 

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -18,6 +18,7 @@ import {GvarListComponent} from './gvars/gvar-list/gvar-list.component';
 import {GvarsComponent} from './gvars/gvars.component';
 import {HomebrewModule} from './homebrew/homebrew.module';
 import {NewDialog} from './new-dialog/new-dialog.component';
+import { GvarLookupComponent } from './gvars/gvar-lookup/gvar-lookup.component';
 
 @NgModule({
   imports: [
@@ -42,6 +43,7 @@ import {NewDialog} from './new-dialog/new-dialog.component';
     NewDialog,
     AttackEditorDialog,
     GvarListComponent,
+    GvarLookupComponent,
   ],
   entryComponents: [
     ConfirmDeleteDialog,

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -4,7 +4,7 @@ import {Observable, of} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {environment} from '../../environments/environment';
 import {Attack, CharacterMeta} from '../schemas/Character';
-import {Customizations, GlobalVar} from '../schemas/Customization';
+import {Customizations} from '../schemas/Customization';
 import {UserInfo, UserStats} from '../schemas/UserInfo';
 import {defaultOptions, defaultTextOptions} from './APIHelper';
 
@@ -57,9 +57,5 @@ export class DashboardService {
 
   getCustomizations(): Observable<Customizations> {
     return this.http.get<Customizations>(customizationsUrl, defaultOptions());
-  }
-
-  getGvars(): Observable<{ owned: GlobalVar[], editable: GlobalVar[] }> {
-    return this.http.get<{ owned: GlobalVar[], editable: GlobalVar[] }>(gvarsUrl, defaultOptions());
   }
 }

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.css
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.css
@@ -1,0 +1,19 @@
+.lookup-id-input {
+  margin-right: 4px;
+  width: 50%;
+}
+
+.gvar-value-container {
+  padding-top: 1em;
+}
+
+.gvar-value-display {
+  white-space: pre-wrap;
+  background-color: rgba(0, 0, 0, 0.1);
+  margin: 0;
+
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.15);
+  border-width: 1px;
+  border-radius: 6px;
+}

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.html
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.html
@@ -1,0 +1,25 @@
+<mat-form-field class="lookup-id-input">
+  <input matInput placeholder="Gvar ID" #lookupIdInput>
+</mat-form-field>
+<button mat-flat-button color="primary" (click)="lookupGvar(lookupIdInput.value)">Lookup</button>
+
+<div *ngIf="activeGvar">
+  <p>
+    {{activeGvar.key}}
+  </p>
+  <p>
+    <i>Owned by: {{activeGvar.owner_name}}</i>
+  </p>
+
+  <mat-divider></mat-divider>
+
+  <div class="gvar-value-container">
+    <pre class="gvar-value-display">{{activeGvar.value}}</pre>
+  </div>
+</div>
+
+<div *ngIf="error">
+  <p style="color: red">
+    {{error}}
+  </p>
+</div>

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.spec.ts
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GvarLookupComponent } from './gvar-lookup.component';
+
+describe('GvarLookupComponent', () => {
+  let component: GvarLookupComponent;
+  let fixture: ComponentFixture<GvarLookupComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GvarLookupComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GvarLookupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.ts
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.ts
@@ -1,0 +1,39 @@
+import {Component, OnInit} from '@angular/core';
+import {isBoolean} from 'util';
+import {GlobalVar} from '../../../schemas/Customization';
+import {GvarService} from '../gvar.service';
+
+@Component({
+  selector: 'avr-gvar-lookup',
+  templateUrl: './gvar-lookup.component.html',
+  styleUrls: ['./gvar-lookup.component.css']
+})
+export class GvarLookupComponent implements OnInit {
+
+  activeGvar: GlobalVar;
+  error: string;
+
+  constructor(private gvarService: GvarService) {
+  }
+
+  ngOnInit() {
+  }
+
+  lookupGvar(key: string) {
+    key = key.trim();
+    console.log(key);
+
+    // HTTP GET /customizations/gvars/:key
+    this.gvarService.getGvar(key)
+      .subscribe(gvar => {
+        this.activeGvar = null;
+        this.error = null;
+        if (isBoolean(gvar) && !gvar) {
+          this.error = 'Failed to get gvar.';
+        } else {
+          this.activeGvar = gvar as GlobalVar;
+        }
+      });
+  }
+
+}

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.ts
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 import {isBoolean} from 'util';
 import {GlobalVar} from '../../../schemas/Customization';
 import {GvarService} from '../gvar.service';
@@ -13,15 +14,22 @@ export class GvarLookupComponent implements OnInit {
   activeGvar: GlobalVar;
   error: string;
 
-  constructor(private gvarService: GvarService) {
+  constructor(private gvarService: GvarService, private route: ActivatedRoute) {
   }
 
   ngOnInit() {
+    this.checkForLookupQuery();
   }
 
   lookupGvar(key: string) {
     key = key.trim();
     console.log(key);
+
+    // set query param for permalinking
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.set('lookup', key);
+    const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
+    history.pushState(null, '', newRelativePathQuery);
 
     // HTTP GET /customizations/gvars/:key
     this.gvarService.getGvar(key)
@@ -36,4 +44,10 @@ export class GvarLookupComponent implements OnInit {
       });
   }
 
+  checkForLookupQuery() {
+    const lookupId = this.route.snapshot.queryParamMap.get('lookup');
+    if (lookupId) {
+      this.lookupGvar(lookupId);
+    }
+  }
 }

--- a/src/app/dashboard/gvars/gvar.service.ts
+++ b/src/app/dashboard/gvars/gvar.service.ts
@@ -1,10 +1,10 @@
-import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {environment} from '../../../environments/environment';
+import {Injectable} from '@angular/core';
 import {Observable, of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {environment} from '../../../environments/environment';
 import {GlobalVar} from '../../schemas/Customization';
 import {defaultOptions, defaultTextOptions} from '../APIHelper';
-import {catchError} from 'rxjs/operators';
 
 const gvarUrl = `${environment.apiURL}/customizations/gvars`;
 
@@ -16,6 +16,10 @@ export class GvarService {
   constructor(private http: HttpClient) {
   }
 
+  getAllGvars(): Observable<{ owned: GlobalVar[], editable: GlobalVar[] }> {
+    return this.http.get<{ owned: GlobalVar[], editable: GlobalVar[] }>(gvarUrl, defaultOptions());
+  }
+
   getGvars(owned: boolean): Observable<GlobalVar[]> {
     return this.http.get<GlobalVar[]>(`${gvarUrl}/${owned ? 'owned' : 'editable'}`, defaultOptions());
   }
@@ -25,6 +29,13 @@ export class GvarService {
     return this.http.post<string>(`${gvarUrl}`, gvar, defaultTextOptions())
       .pipe(
         catchError(this.handleTextError('newGvar'))
+      );
+  }
+
+  getGvar(key: string): Observable<GlobalVar | boolean> {
+    return this.http.get<GlobalVar>(`${gvarUrl}/${key}`, defaultOptions())
+      .pipe(
+        catchError(_ => of(false))
       );
   }
 

--- a/src/app/dashboard/gvars/gvars.component.html
+++ b/src/app/dashboard/gvars/gvars.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <mat-card>
-    <mat-tab-group>
+    <mat-tab-group [(selectedIndex)]="forcedTabIndex">
       <mat-tab label="Owned">
         <avr-gvar-list [data]="(gvars | async)?.owned" [owned]="true"></avr-gvar-list>
       </mat-tab>

--- a/src/app/dashboard/gvars/gvars.component.html
+++ b/src/app/dashboard/gvars/gvars.component.html
@@ -7,6 +7,9 @@
       <mat-tab label="Editable">
         <avr-gvar-list [data]="(gvars | async)?.editable" [owned]="false"></avr-gvar-list>
       </mat-tab>
+      <mat-tab label="Lookup">
+        <avr-gvar-lookup></avr-gvar-lookup>
+      </mat-tab>
     </mat-tab-group>
   </mat-card>
 </div>

--- a/src/app/dashboard/gvars/gvars.component.ts
+++ b/src/app/dashboard/gvars/gvars.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {Observable} from 'rxjs';
 import {GlobalVar} from '../../schemas/Customization';
-import {DashboardService} from '../dashboard.service';
+import {GvarService} from './gvar.service';
 
 @Component({
   selector: 'avr-gvars',
@@ -12,7 +12,7 @@ export class GvarsComponent implements OnInit {
 
   gvars: Observable<{ owned: GlobalVar[]; editable: GlobalVar[] }>;
 
-  constructor(private dashboardService: DashboardService) {
+  constructor(private gvarService: GvarService) {
   }
 
   ngOnInit() {
@@ -20,7 +20,6 @@ export class GvarsComponent implements OnInit {
   }
 
   getCustomizations(): void {
-    this.gvars = this.dashboardService.getGvars();
+    this.gvars = this.gvarService.getAllGvars();
   }
-
 }

--- a/src/app/dashboard/gvars/gvars.component.ts
+++ b/src/app/dashboard/gvars/gvars.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 import {Observable} from 'rxjs';
 import {GlobalVar} from '../../schemas/Customization';
 import {GvarService} from './gvar.service';
@@ -11,15 +12,24 @@ import {GvarService} from './gvar.service';
 export class GvarsComponent implements OnInit {
 
   gvars: Observable<{ owned: GlobalVar[]; editable: GlobalVar[] }>;
+  forcedTabIndex: number;
 
-  constructor(private gvarService: GvarService) {
+  constructor(private gvarService: GvarService, private route: ActivatedRoute) {
   }
 
   ngOnInit() {
     this.getCustomizations();
+    this.checkForLookupQuery();
   }
 
   getCustomizations(): void {
     this.gvars = this.gvarService.getAllGvars();
+  }
+
+  checkForLookupQuery(): void {
+    const lookupId = this.route.snapshot.queryParamMap.get('lookup');
+    if (lookupId) {
+      this.forcedTabIndex = 2;
+    }
   }
 }


### PR DESCRIPTION
Right now, the only way to look up a gvar you don't own that's too long to display in Discord is to write an alias to copy it, then view it in your dashboard. This PR adds a page to view gvars you don't own, so you don't have to do that.

Also moved around the sidebar a little bit in preparation for the Alias Workshop.