### PR TITLE
2019w46

### DIFF
--- a/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.html
+++ b/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.html
@@ -1,6 +1,14 @@
 <h2 mat-dialog-title>Editing Attacks: {{character.name}}</h2>
 
 <mat-dialog-content class="mat-typography" *ngIf="allAttacks">
+  <div>
+    <p>
+      Need help using the editor? Check out the docs
+      <a href="https://avrae.readthedocs.io/en/latest/automation.html" target="_blank"
+         rel="noopener noreferrer">here</a>!
+    </p>
+  </div>
+
   <div fxLayout="row">
     <mat-form-field>
       <mat-label>Select an attack</mat-label>
@@ -31,7 +39,7 @@
 
   <div *ngIf="selectedAttack">
     <div fxLayout="row" fxLayoutGap="4px">
-      <mat-form-field fxFlex>
+      <mat-form-field fxFlex="grow">
         <input matInput placeholder="Attack Name" [(ngModel)]="selectedAttack.name">
       </mat-form-field>
 
@@ -47,6 +55,19 @@
           <mat-icon aria-label="Export to JSON">vertical_align_top</mat-icon>
         </button>
       </span>
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="center center">
+      <mat-checkbox fxFlex [(ngModel)]="selectedAttack.proper">Proper Noun</mat-checkbox>
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Verb" [(ngModel)]="selectedAttack.verb">
+      </mat-form-field>
+
+      <span fxFlex="noshrink">
+        Display: {{character.name}} {{selectedAttack.verb || 'attacks with'}} {{selectedAttack.proper ? selectedAttack.name : 'a ' + selectedAttack.name}}!
+      </span>
+
+      <span fxFlex="grow"></span>
     </div>
 
     <avr-automation-editor [automation]="selectedAttack.automation"></avr-automation-editor>

--- a/src/app/schemas/Character.ts
+++ b/src/app/schemas/Character.ts
@@ -56,11 +56,15 @@ export class Attack {
   name: string;
   automation: AutomationEffect[];
   _v: 2;
+  proper?: boolean;
+  verb?: string;
 
-  constructor(name = '', automation: AutomationEffect[] = []) {
+  constructor(name = '', automation: AutomationEffect[] = [], proper: boolean = false, verb: string = null) {
     this.name = name;
     this.automation = automation;
     this._v = 2;
+    this.proper = proper;
+    this.verb = verb;
   }
 }
 

--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -50,12 +50,14 @@ export class Save extends AutomationEffect {
 
 export class Damage extends AutomationEffect {
   damage: string;
+  overheal: boolean;
   higher?: Map<number, string>;
   cantripScale?: boolean;
 
-  constructor(damage = '', higher?, cantripScale?, meta?) {
+  constructor(damage = '', overheal?, higher?, cantripScale?, meta?) {
     super('damage', meta);
     this.damage = damage;
+    this.overheal = overheal;
     this.higher = higher;
     this.cantripScale = cantripScale;
     this.meta = meta;

--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -4,7 +4,7 @@ export class AutomationEffect {
 
   constructor(type, meta = []) {
     this.type = type;
-    this.meta = meta;
+    this.meta = meta || [];
   }
 
 }
@@ -60,7 +60,6 @@ export class Damage extends AutomationEffect {
     this.overheal = overheal;
     this.higher = higher;
     this.cantripScale = cantripScale;
-    this.meta = meta;
   }
 }
 
@@ -74,7 +73,6 @@ export class TempHP extends AutomationEffect {
     this.amount = amount;
     this.higher = higher;
     this.cantripScale = cantripScale;
-    this.meta = meta;
   }
 }
 
@@ -106,7 +104,6 @@ export class Roll extends AutomationEffect {
     this.name = name;
     this.higher = higher;
     this.cantripScale = cantripScale;
-    this.meta = meta;
     this.hidden = hidden;
   }
 }

--- a/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
@@ -9,6 +9,9 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       <mat-form-field>
         <input matInput placeholder="Damage" (change)="changed.emit()" [(ngModel)]="effect.damage">
       </mat-form-field>
+      <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
+        Allow Overheal
+      </mat-checkbox>
       <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
@@ -6,7 +6,7 @@
           <mat-option *ngFor="let option of availableTypes"
                       [value]="{option: option, meta: false}">Add {{option}}</mat-option>
         </mat-optgroup>
-        <mat-optgroup label="Meta">
+        <mat-optgroup label="Meta" *ngIf="availableMetaTypes.length">
           <mat-option *ngFor="let option of availableMetaTypes"
                       [value]="{option: option, meta: true}">Add meta {{option}}</mat-option>
         </mat-optgroup>

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
@@ -36,7 +36,7 @@ export class NewEffectCardComponent implements OnInit {
 
   ngOnInit() {
     this.availableTypes = typeOptions.get(this.parentType);
-    this.availableMetaTypes = typeOptions.get('meta');
+    this.availableMetaTypes = this.parentType === 'root' ? [] : typeOptions.get('meta');
   }
 
   addEffect() {


### PR DESCRIPTION
Adds documentation to the character attack editor, the ability to specify proper nouns and a custom verb for attacking with a given attack, and the overheal boolean to automation damage effects.

Resolves #123 