### PR TITLE
WEB-033 allow custom spell schools

### DIFF
--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
@@ -40,7 +40,7 @@
 
         <mat-form-field fxFlex>
           <mat-label>School</mat-label>
-          <mat-select [(value)]="spell.school" (selectionChange)="emitChange()">
+          <mat-select [(value)]="spell.school" (selectionChange)="emitChange()" *ngIf="!customSpellSchool">
             <mat-option value="A">Abjuration</mat-option>
             <mat-option value="C">Conjuration</mat-option>
             <mat-option value="D">Divination</mat-option>
@@ -49,7 +49,14 @@
             <mat-option value="I">Illusion</mat-option>
             <mat-option value="N">Necromancy</mat-option>
             <mat-option value="T">Transmutation</mat-option>
+            <mat-option value="Custom" (click)="customSpellSchool = true">Custom</mat-option>
           </mat-select>
+          <input matInput placeholder="School" (change)="emitChange()" [(ngModel)]="spell.school"
+                 *ngIf="customSpellSchool">
+          <button mat-icon-button matSuffix matTooltip="Delete custom school" (click)="customSpellSchool = false"
+                  *ngIf="customSpellSchool">
+            <mat-icon>remove_circle_outline</mat-icon>
+          </button>
         </mat-form-field>
 
         <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.ritual" (change)="emitChange()">Ritual</mat-checkbox>

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.ts
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
-import {Spell} from '../../../../../schemas/homebrew/Spells';
+import {Spell, SPELL_SCHOOLS} from '../../../../../schemas/homebrew/Spells';
 import {UserInfo} from '../../../../../schemas/UserInfo';
 import {JSONExportDialog} from '../../../../../shared/dialogs/json-export-dialog/json-export-dialog.component';
 
@@ -21,10 +21,13 @@ export class SpellDetailComponent implements OnInit {
   @Output() delete = new EventEmitter();
   @Output() moveToEditor = new EventEmitter();
 
+  customSpellSchool: boolean;
+
   constructor(private dialog: MatDialog) {
   }
 
   ngOnInit() {
+    this.customSpellSchool = !SPELL_SCHOOLS.includes(this.spell.school);
   }
 
   emitChange() {


### PR DESCRIPTION
Homebrew: Adds a "Custom" option to the spell school dropdown that when clicked, changes the dropdown into an input and allows the user to enter a custom spell school.

No data model changes are required since spell school is stored as a string anyway.

Resolves #94