### PR TITLE
fix error preventing packs/tomes from loading

### DIFF
--- a/src/app/homebrew-sharing/pack-share/pack-share.component.html
+++ b/src/app/homebrew-sharing/pack-share/pack-share.component.html
@@ -5,7 +5,7 @@
     </span>
     <span class="toolbar-spacer"></span>
     <span>
-      By {{owner.username}}
+      By {{owner?.username || 'Loading...'}}
     </span>
   </mat-toolbar>
 

--- a/src/app/homebrew-sharing/pack-share/pack-share.component.html
+++ b/src/app/homebrew-sharing/pack-share/pack-share.component.html
@@ -5,7 +5,8 @@
     </span>
     <span class="toolbar-spacer"></span>
     <span>
-      By {{owner?.username || 'Loading...'}}
+      <mat-spinner color="accent" diameter="24" *ngIf="!owner"></mat-spinner>
+      <div *ngIf="owner">By {{owner.username}}</div>
     </span>
   </mat-toolbar>
 

--- a/src/app/homebrew-sharing/tome-share/tome-share.component.html
+++ b/src/app/homebrew-sharing/tome-share/tome-share.component.html
@@ -5,7 +5,7 @@
     </span>
     <span class="flex-spacer"></span>
     <span>
-      By {{owner.username}}
+      By {{owner?.username || 'Loading...'}}
     </span>
   </mat-toolbar>
 

--- a/src/app/homebrew-sharing/tome-share/tome-share.component.html
+++ b/src/app/homebrew-sharing/tome-share/tome-share.component.html
@@ -5,7 +5,8 @@
     </span>
     <span class="flex-spacer"></span>
     <span>
-      By {{owner?.username || 'Loading...'}}
+      <mat-spinner color="accent" diameter="24" *ngIf="!owner"></mat-spinner>
+      <div *ngIf="owner">By {{owner.username}}</div>
     </span>
   </mat-toolbar>
 

--- a/src/app/shared/discord.service.ts
+++ b/src/app/shared/discord.service.ts
@@ -2,7 +2,6 @@ import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {environment} from '../../environments/environment';
-import {defaultOptions} from '../dashboard/APIHelper';
 import {UserInfo} from '../schemas/UserInfo';
 
 const discordUrl = `${environment.apiURL}/discord`;
@@ -18,10 +17,11 @@ export class DiscordService {
   }
 
   userById(id: string): Observable<UserInfo> {
-    return this.http.get<UserInfo>(`${discordUrl}/users/${id}`, defaultOptions());
+    return this.http.get<UserInfo>(`${discordUrl}/users/${id}`);
   }
 
-  getUser(id: string) {
+
+  getUser(id: string): Observable<UserInfo> {
     if (this.user_cache.has(id)) {
       return of(this.user_cache.get(id));
     }


### PR DESCRIPTION
Depends on avrae-service v1.3.1.

Logged out users could not view public homebrew packs/tomes since attempts to get the owner username would 403.