### PR TITLE
Show all subcommands without requiring click

### DIFF
--- a/src/app/commands/command-display/command-display.component.html
+++ b/src/app/commands/command-display/command-display.component.html
@@ -4,11 +4,12 @@
   <div class="click-to-expand" (click)="toggleOpen()">
     <p class="command-header">
       <code>{{command.signature}}</code>
-      <mat-icon>{{isOpen ? 'expand_less' : 'expand_more'}}</mat-icon>
+      <mat-icon *ngIf="canBeOpened()">
+        {{isOpen ? 'expand_less' : 'expand_more'}}
+      </mat-icon>
     </p>
     <div class="command-closed-desc" *ngIf="!isOpen">
       <markdown>{{debrace(command.short)}}</markdown>
-      <p class="mat-small has-subcommands" *ngIf="command.subcommands.length"><i>Has subcommands.</i></p>
     </div>
   </div>
 
@@ -23,13 +24,13 @@
         <td><code>{{arg.name}}</code>{{getArgDescriptors(arg)}} - {{arg.desc}}</td>
       </tr>
     </table>
+  </div>
 
-    <div class="command-subcommands" *ngIf="command.subcommands.length">
-      <h4>Subcommands</h4>
-      <mat-accordion>
-        <avr-command-display *ngFor="let subcommand of command.subcommands" [command]="subcommand"
-                             [parentId]="getQualifiedId()"></avr-command-display>
-      </mat-accordion>
-    </div>
+  <div class="command-subcommands" *ngIf="command.subcommands.length">
+    <h4>Subcommands</h4>
+    <mat-accordion>
+      <avr-command-display *ngFor="let subcommand of command.subcommands" [command]="subcommand"
+                           [parentId]="getQualifiedId()"></avr-command-display>
+    </mat-accordion>
   </div>
 </div>

--- a/src/app/commands/command-display/command-display.component.scss
+++ b/src/app/commands/command-display/command-display.component.scss
@@ -33,7 +33,6 @@ mat-divider {
 }
 
 // ==== content ====
-
 .command-desc {
   color: $gray4;
   font-size: 16px;

--- a/src/app/commands/command-display/command-display.component.ts
+++ b/src/app/commands/command-display/command-display.component.ts
@@ -30,9 +30,13 @@ export class CommandDisplayComponent implements OnInit, AfterViewInit {
     }
   }
 
+  canBeOpened() {
+    return this.command.args.length || this.command.docs !== this.command.short;
+  }
+
   toggleOpen() {
     this.isOpen = !this.isOpen;
-    if (this.isOpen) {
+    if (this.isOpen || !this.canBeOpened()) {
       this.setHash();
     }
   }


### PR DESCRIPTION
Helps users find commands they would otherwise have to click on an expansion panel to find.

Also removes the expansion panel arrow from commands that would not display any extra content when expanded.
<img width="998" alt="Screenshot 2020-07-01 at 12 33 45" src="https://user-images.githubusercontent.com/8866981/86284140-21d0a880-bb97-11ea-8567-d9a6228e486d.png">
