### PR TITLE
use local rather than session storage for auth directs

### DIFF
--- a/src/app/SecurityHelper.ts
+++ b/src/app/SecurityHelper.ts
@@ -9,9 +9,10 @@ const scope = encodeURIComponent(oAuthScope);
 
 /// generates and saves an oauth state to sessionStorage (oauth-state) and returns url of discord oauth
 export function navigateToDiscordOauth() {
-  // set oauth state in session storage
+  // set oauth state in local storage
+  // Discord OAuth2 opens a new tab on Android Chrome, so we use localStorage instead of sessionStorage
   const state = generateOauthState();
-  sessionStorage.setItem('oauth-state', state);
+  localStorage.setItem('expected-oauth-state', state);
 
   // do navigation
   window.location.href = getDiscordOauthUrl(state);

--- a/src/app/SecurityHelper.ts
+++ b/src/app/SecurityHelper.ts
@@ -1,4 +1,5 @@
 import {environment} from '../environments/environment';
+import {getLocalStorage, removeLocalStorage, setLocalStorage} from './shared/StorageUtils';
 
 // oauth helpers
 export const oAuthRedirectUri = `${environment.baseURL}/login`;
@@ -12,7 +13,7 @@ export function navigateToDiscordOauth() {
   // set oauth state in local storage
   // Discord OAuth2 opens a new tab on Android Chrome, so we use localStorage instead of sessionStorage
   const state = generateOauthState();
-  localStorage.setItem('expected-oauth-state', state);
+  setLocalStorage('expected-oauth-state', state);
 
   // do navigation
   window.location.href = getDiscordOauthUrl(state);
@@ -38,15 +39,13 @@ export function isLoggedIn() {
 }
 
 export function setToken(token: string) {
-  localStorage.setItem('avrae-token', token);
+  setLocalStorage('avrae-token', token);
 }
 
 export function getToken() {
-  return localStorage.getItem('avrae-token');
+  return getLocalStorage('avrae-token');
 }
 
 export function removeToken() {
-  if (localStorage.getItem('avrae-token')) {
-    localStorage.removeItem('avrae-token');
-  }
+  removeLocalStorage('avrae-token');
 }

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {Observable} from 'rxjs';
 import {getDiscordOauthUrl, isLoggedIn, navigateToDiscordOauth} from './SecurityHelper';
+import {setLocalStorage} from './shared/StorageUtils';
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +21,7 @@ export class AuthGuard implements CanActivate {
       return true;
     } else {
       // the discord auth endpoint requires an exact redirect_uri (no after param) so we store where the user wanted to go in localStorage
-      localStorage.setItem('after-login-redirect', state.url);
+      setLocalStorage('after-login-redirect', state.url);
       navigateToDiscordOauth();
       // > Note: The guard can also tell the router to navigate elsewhere, effectively canceling the current navigation.
       // > When doing so inside a guard, the guard should return false;

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -19,8 +19,8 @@ export class AuthGuard implements CanActivate {
     if (isLoggedIn()) {
       return true;
     } else {
-      // the discord auth endpoint requires an exact redirect_uri (no after param) so we store where the user wanted to go in sessionStorage
-      sessionStorage.setItem('after-login-redirect', state.url);
+      // the discord auth endpoint requires an exact redirect_uri (no after param) so we store where the user wanted to go in localStorage
+      localStorage.setItem('after-login-redirect', state.url);
       navigateToDiscordOauth();
       // > Note: The guard can also tell the router to navigate elsewhere, effectively canceling the current navigation.
       // > When doing so inside a guard, the guard should return false;

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {ApiResponse} from '../dashboard/APIHelper';
 import {removeToken, setToken} from '../SecurityHelper';
+import {getLocalStorage, removeLocalStorage} from '../shared/StorageUtils';
 import {AuthService} from './auth.service';
 
 @Component({
@@ -19,7 +20,7 @@ export class LoginComponent implements OnInit {
 
   ngOnInit() {
     const paramMap = this.activatedRoute.snapshot.queryParamMap;
-    const state = localStorage.getItem('expected-oauth-state');
+    const state = getLocalStorage('expected-oauth-state');
 
     // validate state
     if (state === null || paramMap.get('state') !== state) {
@@ -27,7 +28,7 @@ export class LoginComponent implements OnInit {
       this.working = false;
       return;
     }
-    localStorage.removeItem('expected-oauth-state');
+    removeLocalStorage('expected-oauth-state');
 
     // get code
     const code = paramMap.get('code');
@@ -51,10 +52,10 @@ export class LoginComponent implements OnInit {
       setToken(response.data.jwt);
 
       // login finished, redirect to requested page
-      const postLoginRedirect = localStorage.getItem('after-login-redirect') || '/dashboard/characters';
+      const postLoginRedirect = getLocalStorage('after-login-redirect') || '/dashboard/characters';
       this.router.navigateByUrl(postLoginRedirect)
         .then(() => {
-          localStorage.removeItem('after-login-redirect');
+          removeLocalStorage('after-login-redirect');
         });
     }
   }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -19,7 +19,7 @@ export class LoginComponent implements OnInit {
 
   ngOnInit() {
     const paramMap = this.activatedRoute.snapshot.queryParamMap;
-    const state = sessionStorage.getItem('oauth-state');
+    const state = localStorage.getItem('expected-oauth-state');
 
     // validate state
     if (state === null || paramMap.get('state') !== state) {
@@ -27,7 +27,7 @@ export class LoginComponent implements OnInit {
       this.working = false;
       return;
     }
-    sessionStorage.removeItem('oauth-state');
+    localStorage.removeItem('expected-oauth-state');
 
     // get code
     const code = paramMap.get('code');
@@ -51,10 +51,10 @@ export class LoginComponent implements OnInit {
       setToken(response.data.jwt);
 
       // login finished, redirect to requested page
-      const postLoginRedirect = sessionStorage.getItem('after-login-redirect') || '/dashboard/characters';
+      const postLoginRedirect = localStorage.getItem('after-login-redirect') || '/dashboard/characters';
       this.router.navigateByUrl(postLoginRedirect)
         .then(() => {
-          sessionStorage.removeItem('after-login-redirect');
+          localStorage.removeItem('after-login-redirect');
         });
     }
   }

--- a/src/app/shared/StorageUtils.ts
+++ b/src/app/shared/StorageUtils.ts
@@ -1,0 +1,53 @@
+/// local/session storage helpers
+
+export function getLocalStorage(key: string) {
+  try {
+    return localStorage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function setLocalStorage(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function removeLocalStorage(key: string) {
+  try {
+    localStorage.removeItem(key);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function getSessionStorage(key: string) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function setSessionStorage(key: string, value: string) {
+  try {
+    sessionStorage.setItem(key, value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function removeSessionStorage(key: string) {
+  try {
+    sessionStorage.removeItem(key);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Expected flow: 
```
TAB 1  front page - log in - discord - accept - /login - requested page
```

Actual flow on Android Chrome
```
TAB 1  front page - log in - front page
Discord App                \ discord - accept
TAB 2                                         \ /login (error)
```

This PR changes the storage of the expected OAuth state to use localStorage rather than sessionStorage since sessionStorage is not shared between Tab 1 and Tab 2 on the Android flow.

Fixes #305 