### PR TITLE
add tooltips to the automation editor

### DIFF
--- a/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
@@ -11,6 +11,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       </mat-checkbox>
       <mat-form-field *ngIf="custom">
         <input matInput placeholder="Custom Bonus" (change)="changed.emit()" [(ngModel)]="effect.attackBonus">
+        <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
     <mat-expansion-panel>

--- a/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
@@ -8,6 +8,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
       <mat-form-field>
         <input matInput placeholder="Damage" (change)="changed.emit()" [(ngModel)]="effect.damage">
+        <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
       <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
         Allow Overheal

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
@@ -11,9 +11,11 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       </mat-form-field>
       <mat-form-field fxFlex="1 2 auto">
         <input matInput placeholder="Duration" (change)="changed.emit()" [(ngModel)]="effect.duration">
+        <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
       <mat-form-field fxFlex="2 1 auto">
         <input matInput placeholder="Effects" (change)="changed.emit()" [(ngModel)]="effect.effects">
+        <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
       <mat-checkbox [(ngModel)]="effect.end" (change)="changed.emit();">
         Ticks on end?

--- a/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
@@ -11,6 +11,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       </mat-form-field>
       <mat-form-field>
         <input matInput placeholder="Dice" (change)="changed.emit()" [(ngModel)]="effect.dice">
+        <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
       <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">

--- a/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
@@ -22,6 +22,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       </mat-checkbox>
       <mat-form-field *ngIf="custom">
         <input matInput placeholder="Custom DC" (change)="changed.emit()" [(ngModel)]="effect.dc">
+        <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
     <mat-expansion-panel>

--- a/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
@@ -8,6 +8,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
       <mat-form-field>
         <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount">
+        <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
       <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">

--- a/src/app/shared/automation-editor/effect-editor/text-effect/text-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/text-effect/text-effect.component.ts
@@ -8,6 +8,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
     <mat-form-field class="wide">
         <textarea matInput placeholder="Description" rows="5" (change)="changed.emit()"
                   [(ngModel)]="effect.text"></textarea>
+      <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
     </mat-form-field>
   `,
   styleUrls: ['../effect-editor.component.css']


### PR DESCRIPTION
These should make it less ambiguous what type of code is allowed in what field.

<img width="599" alt="Screenshot 2020-08-07 at 15 32 48" src="https://user-images.githubusercontent.com/8866981/89693443-52f17680-d8c3-11ea-8cf2-ad2a54c24698.png">
<img width="346" alt="Screenshot 2020-08-07 at 15 32 54" src="https://user-images.githubusercontent.com/8866981/89693448-55ec6700-d8c3-11ea-9f84-31549efe954f.png">

