### PR TITLE
Add desc to iEffects in the Automation Editor

### DIFF
--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -81,13 +81,15 @@ export class IEffect extends AutomationEffect {
   duration: number | string;
   effects: string;
   end?: boolean;
+  desc?: string;
 
-  constructor(name = '', duration = '', effects = '', end = false, meta?) {
+  constructor(name = '', duration = '', effects = '', desc = '',end = false, meta?) {
     super('ieffect', meta);
     this.name = name;
     this.duration = duration;
     this.effects = effects;
     this.end = end;
+    this.desc = desc;
   }
 }
 

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
@@ -21,6 +21,13 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
         Ticks on end?
       </mat-checkbox>
     </div>
+    <div fxLayout="row">
+      <mat-form-field class="wide">
+        <textarea matInput placeholder="Description" rows="3" (change)="changed.emit()"
+            [(ngModel)]="effect.desc" maxlength="500"></textarea>
+        <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
+      </mat-form-field>
+    </div>
   `,
   styleUrls: ['../effect-editor.component.css']
 })


### PR DESCRIPTION
### Summary
Adds a description field to the automation editor for iEffects, tying into https://github.com/avrae/avrae/pull/1285

Resolves #890 (AFR-465)

Description:
![image](https://user-images.githubusercontent.com/5848891/94977111-8f60dd80-04d4-11eb-98c2-f199525f4152.png)

No description:
![image](https://user-images.githubusercontent.com/5848891/94977101-8839cf80-04d4-11eb-9011-fd71d9657485.png)


### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
