### PR TITLE
SSR: Alias Workshop Meta

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,16 +1,17 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
+import {CommandsComponent} from './commands/commands.component';
+import {ErrorComponent} from './error/error.component';
 
 import {HomeComponent} from './home/home.component';
 import {LoginComponent} from './login/login.component';
-import {ErrorComponent} from './error/error.component';
-import {CommandsComponent} from './commands/commands.component';
 
 const routes: Routes = [
   {path: '', component: HomeComponent},
   {path: 'login', component: LoginComponent},
   {path: 'commands', component: CommandsComponent},
   {path: 'dashboard', loadChildren: () => import('./dashboard/dashboard.module').then(mod => mod.DashboardModule)},
+  {path: 'ssr', loadChildren: () => import('./ssr/ssr.module').then(mod => mod.SsrModule)},
   {path: '**', component: ErrorComponent}
 ];
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,13 +5,14 @@ import {ErrorComponent} from './error/error.component';
 
 import {HomeComponent} from './home/home.component';
 import {LoginComponent} from './login/login.component';
+import {SsrGuard} from './ssr/ssr.guard';
 
 const routes: Routes = [
   {path: '', component: HomeComponent},
   {path: 'login', component: LoginComponent},
   {path: 'commands', component: CommandsComponent},
   {path: 'dashboard', loadChildren: () => import('./dashboard/dashboard.module').then(mod => mod.DashboardModule)},
-  {path: 'ssr', loadChildren: () => import('./ssr/ssr.module').then(mod => mod.SsrModule)},
+  {path: 'ssr', loadChildren: () => import('./ssr/ssr.module').then(mod => mod.SsrModule), canLoad: [SsrGuard]},
   {path: '**', component: ErrorComponent}
 ];
 

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,7 +1,6 @@
 import {isPlatformServer} from '@angular/common';
 import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
-import {ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
-import {Observable} from 'rxjs';
+import {ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot} from '@angular/router';
 import {isLoggedIn, navigateToDiscordOauth} from './SecurityHelper';
 import {setLocalStorage} from './shared/StorageUtils';
 
@@ -18,11 +17,13 @@ export class AuthGuard implements CanActivate, CanActivateChild {
 
   canActivate(
     next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    state: RouterStateSnapshot): boolean {
     if (isLoggedIn()) {
       return true;
     } else if (isPlatformServer(this.platformId)) {
       // servers cannot do auth
+      // try and route to the ssr module - if it doesn't exist this will render the home page instead
+      this.router.navigateByUrl(`/ssr${state.url}`);
       return false;
     } else {
       // the discord auth endpoint requires an exact redirect_uri (no after param) so we store where the user wanted to go in localStorage
@@ -37,7 +38,7 @@ export class AuthGuard implements CanActivate, CanActivateChild {
 
   canActivateChild(
     childRoute: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    state: RouterStateSnapshot) {
     return this.canActivate(childRoute, state);
   }
 }

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -1,16 +1,18 @@
-import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
+import {isPlatformServer} from '@angular/common';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {Observable} from 'rxjs';
-import {getDiscordOauthUrl, isLoggedIn, navigateToDiscordOauth} from './SecurityHelper';
+import {isLoggedIn, navigateToDiscordOauth} from './SecurityHelper';
 import {setLocalStorage} from './shared/StorageUtils';
 
 @Injectable({
   providedIn: 'root'
 })
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate, CanActivateChild {
 
   constructor(
-    private router: Router
+    private router: Router,
+    @Inject(PLATFORM_ID) private platformId: Object
   ) {
   }
 
@@ -19,6 +21,9 @@ export class AuthGuard implements CanActivate {
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (isLoggedIn()) {
       return true;
+    } else if (isPlatformServer(this.platformId)) {
+      // servers cannot do auth
+      return false;
     } else {
       // the discord auth endpoint requires an exact redirect_uri (no after param) so we store where the user wanted to go in localStorage
       setLocalStorage('after-login-redirect', state.url);
@@ -28,5 +33,11 @@ export class AuthGuard implements CanActivate {
       // https://angular.io/guide/router#milestone-5-route-guards
       return false;
     }
+  }
+
+  canActivateChild(
+    childRoute: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.canActivate(childRoute, state);
   }
 }

--- a/src/app/dashboard/workshop/collection/collection.component.ts
+++ b/src/app/dashboard/workshop/collection/collection.component.ts
@@ -4,7 +4,6 @@ import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {Meta} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
-import {environment} from '../../../../environments/environment';
 import {DiscordUser, PartialGuild} from '../../../schemas/Discord';
 import {WorkshopBindings, WorkshopCollectionFull} from '../../../schemas/Workshop';
 import {DiscordService} from '../../../shared/discord.service';
@@ -67,7 +66,6 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
     this.loadOwner();
     this.loadEditors();
     this.loadBindings();
-    this.updateMeta();
   }
 
   onEditBindings() {
@@ -160,25 +158,5 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
 
   goBack() {
     this.location.back();
-  }
-
-  updateMeta() {
-    this.meta.updateTag({
-      name: 'description',
-      content: `${this.collection.description}\nView ${this.collection.name} on Avrae Homebrew.`.trim()
-    });
-    this.meta.updateTag(
-      {property: 'og:title', content: this.collection.name}
-    );
-    this.meta.updateTag(
-      {property: 'og:url', content: `${environment.baseURL}/${this.route.snapshot.url.join('/')}`}
-    );
-    this.meta.updateTag(
-      {property: 'og:image', content: this.collection.image}
-    );
-    this.meta.updateTag({
-      property: 'og:description',
-      content: `${this.collection.description}\nView ${this.collection.name} on Avrae Homebrew.`.trim()
-    });
   }
 }

--- a/src/app/dashboard/workshop/collection/collection.component.ts
+++ b/src/app/dashboard/workshop/collection/collection.component.ts
@@ -2,7 +2,9 @@ import {Location} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
+import {Meta} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
+import {environment} from '../../../../environments/environment';
 import {DiscordUser, PartialGuild} from '../../../schemas/Discord';
 import {WorkshopBindings, WorkshopCollectionFull} from '../../../schemas/Workshop';
 import {DiscordService} from '../../../shared/discord.service';
@@ -32,7 +34,7 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
   guildContext: PartialGuild | null;
 
   constructor(private route: ActivatedRoute, private router: Router, private snackBar: MatSnackBar,
-              private dialog: MatDialog, private location: Location,
+              private dialog: MatDialog, private location: Location, private meta: Meta,
               private workshopService: WorkshopService, private discordService: DiscordService) {
     super(snackBar, workshopService, discordService);
   }
@@ -65,6 +67,7 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
     this.loadOwner();
     this.loadEditors();
     this.loadBindings();
+    this.updateMeta();
   }
 
   onEditBindings() {
@@ -157,5 +160,25 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
 
   goBack() {
     this.location.back();
+  }
+
+  updateMeta() {
+    this.meta.updateTag({
+      name: 'description',
+      content: `${this.collection.description}\nView ${this.collection.name} on Avrae Homebrew.`.trim()
+    });
+    this.meta.updateTag(
+      {property: 'og:title', content: this.collection.name}
+    );
+    this.meta.updateTag(
+      {property: 'og:url', content: `${environment.baseURL}/${this.route.snapshot.url.join('/')}`}
+    );
+    this.meta.updateTag(
+      {property: 'og:image', content: this.collection.image}
+    );
+    this.meta.updateTag({
+      property: 'og:description',
+      content: `${this.collection.description}\nView ${this.collection.name} on Avrae Homebrew.`.trim()
+    });
   }
 }

--- a/src/app/dashboard/workshop/workshop-routing.module.ts
+++ b/src/app/dashboard/workshop/workshop-routing.module.ts
@@ -7,7 +7,7 @@ import {MyWorkComponent} from './my-work/my-work.component';
 import {WorkshopExploreComponent} from './workshop-explore.component';
 
 const routes: Routes = [
-  {path: '', component: WorkshopExploreComponent},
+  {path: '', component: WorkshopExploreComponent, pathMatch: 'full'},
   {path: 'my-subscriptions', component: MySubscriptionsComponent},
   {path: 'my-work', component: MyWorkComponent},
   {path: ':id', component: CollectionComponent},

--- a/src/app/dashboard/workshop/workshop.service.ts
+++ b/src/app/dashboard/workshop/workshop.service.ts
@@ -45,7 +45,8 @@ export class WorkshopService {
   }
 
   getCollection(id: string): Observable<ApiResponse<WorkshopCollection>> {
-    return this.http.get<ApiResponse<WorkshopCollection>>(`${baseUrl}/collection/${id}`, defaultOptions())
+    // gets a collection without auth
+    return this.http.get<ApiResponse<WorkshopCollection>>(`${baseUrl}/collection/${id}`)
       .pipe(catchError(defaultErrorHandler));
   }
 

--- a/src/app/ssr/README.md
+++ b/src/app/ssr/README.md
@@ -1,0 +1,6 @@
+# ssr
+
+This directory contains special routes that should only ever be
+accessed by a server when performing SSR.
+
+These are exported and used in the AuthGuard to divert a server to these routes.

--- a/src/app/ssr/ssr-routing.module.ts
+++ b/src/app/ssr/ssr-routing.module.ts
@@ -1,0 +1,15 @@
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+import {WorkshopCollectionSsrComponent} from './workshop-collection-ssr.component';
+
+const routes: Routes = [
+  {path: 'dashboard/workshop/:id', component: WorkshopCollectionSsrComponent},  // Alias Workshop collection meta (#350)
+  {path: '**'}  // no component, this page is not ssr-able - render just background color until client renders it
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SsrRoutingModule {
+}

--- a/src/app/ssr/ssr.guard.ts
+++ b/src/app/ssr/ssr.guard.ts
@@ -1,0 +1,28 @@
+import {isPlatformServer} from '@angular/common';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {ActivatedRouteSnapshot, CanActivate, CanLoad, Route, RouterStateSnapshot, UrlSegment} from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SsrGuard implements CanActivate, CanLoad {
+  constructor(@Inject(PLATFORM_ID) private platformId: Object) {
+  }
+
+  // only allow activation if this is a server
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): boolean {
+    return this._check();
+  }
+
+  canLoad(
+    route: Route,
+    segments: UrlSegment[]): boolean {
+    return this._check();
+  }
+
+  _check(): boolean {
+    return isPlatformServer(this.platformId);
+  }
+}

--- a/src/app/ssr/ssr.module.ts
+++ b/src/app/ssr/ssr.module.ts
@@ -1,0 +1,16 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {SsrRoutingModule} from './ssr-routing.module';
+import { WorkshopCollectionSsrComponent } from './workshop-collection-ssr.component';
+
+
+@NgModule({
+  declarations: [WorkshopCollectionSsrComponent],
+  imports: [
+    CommonModule,
+    SsrRoutingModule
+  ]
+})
+export class SsrModule {
+}

--- a/src/app/ssr/workshop-collection-ssr.component.ts
+++ b/src/app/ssr/workshop-collection-ssr.component.ts
@@ -42,13 +42,14 @@ export class WorkshopCollectionSsrComponent implements OnInit {
     this.meta.updateTag(
       {property: 'og:url', content: `${environment.baseURL}/${this.route.snapshot.url.join('/')}`}
     );
-    this.meta.updateTag(
-      {property: 'og:image', content: collection.image}
-    );
+    if (collection.image) {
+      this.meta.updateTag(
+        {property: 'og:image', content: collection.image}
+      );
+    }
     this.meta.updateTag({
       property: 'og:description',
       content: `${collection.description}\nView ${collection.name} on the Alias Workshop.`.trim()
     });
   }
-
 }

--- a/src/app/ssr/workshop-collection-ssr.component.ts
+++ b/src/app/ssr/workshop-collection-ssr.component.ts
@@ -1,0 +1,54 @@
+import {Component, OnInit} from '@angular/core';
+import {Meta} from '@angular/platform-browser';
+import {ActivatedRoute, Router} from '@angular/router';
+import {environment} from '../../environments/environment';
+import {WorkshopService} from '../dashboard/workshop/workshop.service';
+import {WorkshopCollection} from '../schemas/Workshop';
+
+@Component({
+  selector: 'avr-workshop-collection-ssr',
+  template: ``,  // show the dark void of nothingness - servers don't care anyway
+  styles: []
+})
+export class WorkshopCollectionSsrComponent implements OnInit {
+
+  constructor(private route: ActivatedRoute, private router: Router, private meta: Meta,
+              private workshopService: WorkshopService) {
+  }
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe(
+      params => this.loadCollection(params.get('id'))
+    );
+  }
+
+  loadCollection(id: string) {
+    this.workshopService.getCollection(id)
+      .subscribe(response => {
+        if (response.success) {
+          this.setMetaFromCollection(response.data);
+        }
+      });
+  }
+
+  setMetaFromCollection(collection: WorkshopCollection) {
+    this.meta.updateTag({
+      name: 'description',
+      content: `${collection.description}\nView ${collection.name} on the Alias Workshop.`.trim()
+    });
+    this.meta.updateTag(
+      {property: 'og:title', content: collection.name}
+    );
+    this.meta.updateTag(
+      {property: 'og:url', content: `${environment.baseURL}/${this.route.snapshot.url.join('/')}`}
+    );
+    this.meta.updateTag(
+      {property: 'og:image', content: collection.image}
+    );
+    this.meta.updateTag({
+      property: 'og:description',
+      content: `${collection.description}\nView ${collection.name} on the Alias Workshop.`.trim()
+    });
+  }
+
+}


### PR DESCRIPTION
### Summary
Resolves #350 

This handles rendering meta tags for alias workshop collections by, when a request to a path that normally requires auth is made on a server, rerouting that request for the server only to a special SSR component. This allows the server to render parts of the original destination that don't require auth (e.g. collection title), expose those in the meta tags, and allow the client to handle the rendering of the rest of the original request (or, if the client was a crawler, let the client have a little bit of info about what lives there).

It's not the most elegant solution, but hey 😛 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
