### PR TITLE
2020w43

### DIFF
--- a/src/app/dashboard/workshop/collection/collection.component.ts
+++ b/src/app/dashboard/workshop/collection/collection.component.ts
@@ -101,7 +101,7 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
 
   onGuildSubscribe(guild: PartialGuild) {
     this.doGuildSubscribe(guild).subscribe(resp => {
-      if (resp.success && this.guildContext.id === guild.id) {
+      if (resp.success && this.guildContext && this.guildContext.id === guild.id) {
         this.bindings = resp.data;
       }
     });

--- a/src/app/dashboard/workshop/collection/collection.component.ts
+++ b/src/app/dashboard/workshop/collection/collection.component.ts
@@ -101,7 +101,7 @@ export class CollectionComponent extends CollectionSubscriber implements OnInit 
 
   onGuildSubscribe(guild: PartialGuild) {
     this.doGuildSubscribe(guild).subscribe(resp => {
-      if (resp.success && this.guildContext && this.guildContext.id === guild.id) {
+      if (resp.success && this.guildContext?.id === guild.id) {
         this.bindings = resp.data;
       }
     });

--- a/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
@@ -14,7 +14,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
-    <mat-expansion-panel>
+    <mat-expansion-panel class="hoverable">
       <mat-expansion-panel-header>
         <mat-panel-title>
           On Hit
@@ -24,7 +24,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       <avr-new-effect-card [metaParent]="effect.meta" [parent]="effect.hit"
                            [parentType]="effect.type" (changed)="changed.emit()"></avr-new-effect-card>
     </mat-expansion-panel>
-    <mat-expansion-panel>
+    <mat-expansion-panel class="hoverable">
       <mat-expansion-panel-header>
         <mat-panel-title>
           On Miss

--- a/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
@@ -25,7 +25,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
-    <mat-expansion-panel>
+    <mat-expansion-panel class="hoverable">
       <mat-expansion-panel-header>
         <mat-panel-title>
           On Fail
@@ -35,7 +35,7 @@ import {Spell} from '../../../../schemas/homebrew/Spells';
       <avr-new-effect-card [metaParent]="effect.meta" [parent]="effect.fail"
                            [parentType]="effect.type" (changed)="changed.emit()"></avr-new-effect-card>
     </mat-expansion-panel>
-    <mat-expansion-panel>
+    <mat-expansion-panel class="hoverable">
       <mat-expansion-panel-header>
         <mat-panel-title>
           On Success

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
@@ -2,14 +2,8 @@
   <span>
     <mat-form-field>
       <mat-select [(value)]="toAddType" placeholder="Choose effect to add">
-        <mat-optgroup label="Effects">
           <mat-option *ngFor="let option of availableTypes"
                       [value]="{option: option, meta: false}">Add {{option}}</mat-option>
-        </mat-optgroup>
-        <mat-optgroup label="Meta" *ngIf="availableMetaTypes.length">
-          <mat-option *ngFor="let option of availableMetaTypes"
-                      [value]="{option: option, meta: true}">Add meta {{option}}</mat-option>
-        </mat-optgroup>
       </mat-select>
     </mat-form-field>
   </span>

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
@@ -3,7 +3,7 @@
     <mat-form-field>
       <mat-select [(value)]="toAddType" placeholder="Choose effect to add">
           <mat-option *ngFor="let option of availableTypes"
-                      [value]="{option: option, meta: false}">Add {{option}}</mat-option>
+                      [value]="option">Add {{option}}</mat-option>
       </mat-select>
     </mat-form-field>
   </span>

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
@@ -1,13 +1,13 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {Attack, Damage, IEffect, Roll, Save, AutomationEffect, Target, TempHP, Text} from '../../../schemas/homebrew/AutomationEffects';
+import {Attack, AutomationEffect, Damage, IEffect, Roll, Save, Target, TempHP, Text} from '../../../schemas/homebrew/AutomationEffects';
 
 const typeOptions = new Map<string, Array<string>>(
   [
-    ['root', ['target', 'text', 'attack and damage (Preset)', 'save for half (Preset)']],
-    ['meta', ['roll']],
-    ['target', ['attack', 'save', 'damage', 'temphp', 'ieffect']],
-    ['attack', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'text']],
-    ['save', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'text']],
+    ['root', ['target', 'roll', 'text', 'attack and damage (Preset)', 'save for half (Preset)']],
+    ['meta', []],
+    ['target', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll']],
+    ['attack', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text']],
+    ['save', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text']],
     ['damage', []],
     ['temphp', []],
     ['ieffect', []],
@@ -87,6 +87,9 @@ export class NewEffectCardComponent implements OnInit {
     this.parent.push(effect);
   }
 
+  /**
+   * @deprecated
+   */
   newMeta(effect: AutomationEffect) {
     this.metaParent.push(effect);
   }


### PR DESCRIPTION
### Summary
- removes the concept of meta effects in Automation (not breaking - UI just shows Roll effects normally now)
- fixes attack/save onSuccess/onFail/etc panel not highlighting on hover
- fixes issue where error would be logged when subscribing to a workshop collection outside of a guild context

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
