### PR TITLE
AVR-726 display error if a collection in batch request was private

### DIFF
--- a/src/app/dashboard/workshop/my-subscriptions/my-subscriptions.component.ts
+++ b/src/app/dashboard/workshop/my-subscriptions/my-subscriptions.component.ts
@@ -99,6 +99,10 @@ export class MySubscriptionsComponent implements OnInit {
             // ensure the collections populate in the requested order
             this.sortCollections();
             this.loading = false;
+            // #1438 batch returns fewer collections if some are private
+            if (this.collections.length != ids.length) {
+              this.error = 'One or more collections were hidden because they are private.';
+            }
           } else {
             this.error = response.error;
           }

--- a/src/app/dashboard/workshop/workshop-explore.component.html
+++ b/src/app/dashboard/workshop/workshop-explore.component.html
@@ -72,13 +72,14 @@
   </div>
 
   <div class="paginator-container mat-typography ignore-theme"
-       *ngIf="collections?.length === COLLECTIONS_PER_PAGE || page > 1">
+       *ngIf="expectedCollectionIds?.length === COLLECTIONS_PER_PAGE || page > 1">
     <div class="paginator mat-elevation-z3">
       <button mat-icon-button aria-label="Previous page button" *ngIf="page > 1" (click)="onPreviousPage()">
         <mat-icon>chevron_left</mat-icon>
       </button>
       <span>Page {{page}}</span>
-      <button mat-icon-button aria-label="Next page button" *ngIf="collections?.length === COLLECTIONS_PER_PAGE"
+      <button mat-icon-button aria-label="Next page button"
+              *ngIf="expectedCollectionIds?.length === COLLECTIONS_PER_PAGE"
               (click)="onNextPage()">
         <mat-icon>chevron_right</mat-icon>
       </button>

--- a/src/app/dashboard/workshop/workshop-explore.component.ts
+++ b/src/app/dashboard/workshop/workshop-explore.component.ts
@@ -20,6 +20,7 @@ export class WorkshopExploreComponent implements OnInit {
 
   // state
   loading = true;
+  expectedCollectionIds: string[] = [];  // the ids of the collections we currently want (some may not be displayed in some edge cases where a collection is private)
   collections: WorkshopCollection[] = [];
   validTags: WorkshopTag[];  // all valid tags
   filteredTags: [string, WorkshopTag[]][] = [];  // list of tuples of (category, tags) of tags that match query in search
@@ -109,6 +110,7 @@ export class WorkshopExploreComponent implements OnInit {
   }
 
   loadCollectionsFromIds(ids: string[]) {
+    this.expectedCollectionIds = ids;
     if (ids.length === 0) {
       this.loading = false;
     } else {
@@ -117,6 +119,10 @@ export class WorkshopExploreComponent implements OnInit {
           if (response.success) {
             this.collections.push(...response.data);
             this.loading = false;
+            // #1438 batch returns fewer collections if some are private
+            if (this.collections.length != this.expectedCollectionIds.length) {
+              this.error = 'One or more collections were hidden because they are private.';
+            }
           } else {
             this.error = response.error;
           }


### PR DESCRIPTION
### Summary
Requires avrae/avrae-service#30.
Displays an error if the batch request returned less collections than requested (i.e. the user cannot see one ore more due to them being private).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
