### PR TITLE
Add support for creating Use Counter effects in Automation editor

### DIFF
--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -157,3 +157,26 @@ export class Condition extends AutomationEffect {
     this.errorBehaviour = errorBehaviour;
   }
 }
+
+export class UseCounter extends AutomationEffect {
+  counter: string | SpellSlotReference; // | FeatureReference;
+  amount: IntExpression;
+  allowOverflow?: boolean;
+  errorBehaviour?: string | null;
+
+  constructor(counter = '', amount = '', allowOverflow = false, errorBehaviour = 'warn', meta?) {
+    super('counter', meta);
+    this.counter = counter;
+    this.amount = amount;
+    this.allowOverflow = allowOverflow;
+    this.errorBehaviour = errorBehaviour;
+  }
+}
+
+export class SpellSlotReference {
+  slot: number;
+
+  constructor(slot) {
+    this.slot = slot;
+  }
+}

--- a/src/app/shared/automation-editor/automation-editor.module.ts
+++ b/src/app/shared/automation-editor/automation-editor.module.ts
@@ -6,6 +6,7 @@ import {MaterialModule} from '../../material/material.module';
 import {AutomationEditorComponent} from './automation-editor.component';
 import {AttackEffectComponent} from './effect-editor/attack-effect/attack-effect.component';
 import {ConditionEffectComponent} from './effect-editor/condition-effect/condition-effect.component';
+import {CounterEffectComponent} from './effect-editor/counter-effect/counter-effect.component';
 import {DamageEffectComponent} from './effect-editor/damage-effect/damage-effect.component';
 import {EffectEditorComponent} from './effect-editor/effect-editor.component';
 import {HigherLevelComponent} from './effect-editor/higher-level/higher-level.component';
@@ -40,6 +41,7 @@ import {NewEffectCardComponent} from './new-effect-card/new-effect-card.componen
     AutomationEditorComponent,
     VariableEffectComponent,
     ConditionEffectComponent,
+    CounterEffectComponent,
   ],
   exports: [AutomationEditorComponent]
 })

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.spec.ts
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CounterEffectComponent } from './counter-effect.component';
+
+describe('CounterEffectComponent', () => {
+  let component: CounterEffectComponent;
+  let fixture: ComponentFixture<CounterEffectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CounterEffectComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CounterEffectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
@@ -1,0 +1,85 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {SpellSlotReference, UseCounter} from '../../../../schemas/homebrew/AutomationEffects';
+import {Spell} from '../../../../schemas/homebrew/Spells';
+
+@Component({
+  selector: 'avr-counter-effect',
+  template: `
+    <div>
+      <span>Use a </span>
+
+      <mat-form-field>
+        <mat-label>Counter Type</mat-label>
+        <mat-select [(value)]="counterType" (selectionChange)="changed.emit(); onCounterTypeChange()">
+          <mat-option value="counter">custom counter</mat-option>
+          <mat-option value="slot">spell slot</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <span [ngSwitch]="counterType">
+        <span *ngSwitchDefault>
+          <span> named </span>
+          <mat-form-field>
+            <input matInput placeholder="Counter Name" (change)="changed.emit()" [(ngModel)]="effect.counter">
+          </mat-form-field>
+        </span>
+
+        <span *ngSwitchCase="'slot'">
+          <span> of level </span>
+          <mat-form-field>
+            <input matInput placeholder="Slot Level" type="number" max="9" min="1" (change)="changed.emit()"
+                   [(ngModel)]="effect.counter.slot">
+          </mat-form-field>
+        </span>
+      </span>
+    </div>
+
+    <div>
+      <mat-form-field>
+        <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount">
+        <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
+      </mat-form-field>
+
+      <mat-checkbox [(ngModel)]="effect.allowOverflow" (change)="changed.emit()" style="margin-left: 4px;">
+        Allow Overflow
+      </mat-checkbox>
+    </div>
+
+    <mat-form-field>
+      <mat-label>Error Behaviour</mat-label>
+      <mat-select [(value)]="effect.errorBehaviour" (selectionChange)="changed.emit()">
+        <mat-option [value]="null">Ignore</mat-option>
+        <mat-option value="warn">Show Warning</mat-option>
+        <mat-option value="raise">Stop Execution</mat-option>
+      </mat-select>
+    </mat-form-field>
+  `,
+  styleUrls: ['../effect-editor.component.css']
+})
+export class CounterEffectComponent implements OnInit {
+
+  @Input() effect: UseCounter;
+  @Input() spell: Spell;
+  @Output() changed = new EventEmitter();
+  counterType: 'counter' | 'slot';
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    if (typeof this.effect.counter === 'string') {
+      this.counterType = 'counter';
+    } else if ('slot' in this.effect.counter) {
+      this.counterType = 'slot';
+    }
+  }
+
+  onCounterTypeChange(): void {
+    if (this.counterType === 'counter') {
+      this.effect.counter = '';
+    } else if (this.counterType === 'slot') {
+      this.effect.counter = new SpellSlotReference(1);
+    }
+  }
+
+}

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.html
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.html
@@ -38,6 +38,9 @@
       <avr-condition-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
                        *ngSwitchCase="'condition'"></avr-condition-effect>
 
+      <avr-counter-effect [effect]="effect" [spell]="spell" (changed)="changed.emit()"
+                            *ngSwitchCase="'counter'"></avr-counter-effect>
+
       <div *ngSwitchDefault>
         You should not see this text. If you do, that's a bug! Please report that {{effect.type}} is not handled on the
         dev server!

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.html
@@ -1,16 +1,17 @@
 <mat-card fxLayout="row" fxLayoutAlign="start center" class="new-effect-card">
   <span>
     <mat-form-field>
-      <mat-select [(value)]="toAddType" placeholder="Choose effect to add">
-          <mat-option *ngFor="let option of availableTypes"
-                      [value]="option">Add {{option}}</mat-option>
+      <mat-select placeholder="Add New Effect">
+          <mat-option *ngFor="let option of availableTypes" (click)="addEffect(option)">
+            Add {{option}}
+          </mat-option>
       </mat-select>
     </mat-form-field>
   </span>
-  <span class="toolbar-spacer"></span>
-  <span>
-    <button mat-icon-button (click)="addEffect()" matTooltip="Add Effect">
-      <mat-icon aria-label="New">add</mat-icon>
-    </button>
-  </span>
+<!--  <span class="toolbar-spacer"></span>-->
+<!--  <span>-->
+<!--    <button mat-icon-button (click)="addEffect()" matTooltip="Add Effect">-->
+<!--      <mat-icon aria-label="New">add</mat-icon>-->
+<!--    </button>-->
+<!--  </span>-->
 </mat-card>

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
@@ -42,7 +42,6 @@ export class NewEffectCardComponent implements OnInit {
   @Input() metaParent: Array<AutomationEffect>;  // deprecated, unused
   @Input() parentType: string;
   @Output() changed = new EventEmitter();
-  toAddType: string;
   availableTypes: Array<string>;
 
   constructor() {
@@ -52,9 +51,9 @@ export class NewEffectCardComponent implements OnInit {
     this.availableTypes = typeOptions.get(this.parentType);
   }
 
-  addEffect() {
+  addEffect(toAddType) {
     let effect: AutomationEffect;
-    switch (this.toAddType) {
+    switch (toAddType) {
       case 'target':
         effect = new Target();
         break;

--- a/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
+++ b/src/app/shared/automation-editor/new-effect-card/new-effect-card.component.ts
@@ -10,22 +10,24 @@ import {
   SetVariable,
   Target,
   TempHP,
-  Text
+  Text,
+  UseCounter
 } from '../../../schemas/homebrew/AutomationEffects';
 
 const typeOptions = new Map<string, Array<string>>(
   [
-    ['root', ['target', 'roll', 'text', 'variable', 'condition', 'attack and damage (Preset)', 'save for half (Preset)']],
-    ['target', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'variable', 'condition']],
-    ['attack', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition']],
-    ['save', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition']],
+    ['root', ['target', 'roll', 'text', 'variable', 'condition', 'counter', 'attack and damage (Preset)', 'save for half (Preset)']],
+    ['target', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'variable', 'condition', 'counter']],
+    ['attack', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition', 'counter']],
+    ['save', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition', 'counter']],
     ['damage', []],
     ['temphp', []],
     ['ieffect', []],
     ['roll', []],
     ['text', []],
     ['variable', []],
-    ['condition', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition']]
+    ['condition', ['attack', 'save', 'damage', 'temphp', 'ieffect', 'roll', 'text', 'variable', 'condition', 'counter']],
+    ['counter', []]
   ]
 );
 
@@ -82,6 +84,9 @@ export class NewEffectCardComponent implements OnInit {
         break;
       case 'condition':
         effect = new Condition();
+        break;
+      case 'counter':
+        effect = new UseCounter();
         break;
       case 'attack and damage (Preset)':
         this.parent.push(...generateAttackAndDamagePreset());


### PR DESCRIPTION
### Summary
See avrae/avrae#917. This adds the GUI to create these effects.

Also made creating a new effect take one less click by creating it when the user selects the effect rather than requiring a separate "create" click.

CI is failing because GH actions' Chrome is not up to date :(

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
