### PR TITLE
Adds nocritical to interface

### DIFF
--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -61,13 +61,15 @@ export class Damage extends AutomationEffect {
   overheal: boolean;
   higher?: HigherLevels;
   cantripScale?: boolean;
+  nocritical?: boolean
 
-  constructor(damage = '', overheal?, higher?, cantripScale?, meta?) {
+  constructor(damage = '', overheal?, higher?, cantripScale?, nocrtical?, meta?) {
     super('damage', meta);
     this.damage = damage;
     this.overheal = overheal;
     this.higher = higher;
     this.cantripScale = cantripScale;
+    this.nocritical = nocrtical;
   }
 }
 

--- a/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
@@ -13,6 +13,9 @@ import {EffectComponent} from '../shared/EffectComponent';
       <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
         Allow Overheal
       </mat-checkbox>
+      <mat-checkbox [(ngModel)]="effect.nocritical" (change)="changed.emit()">
+        Prevent Critical Damage
+      </mat-checkbox>
       <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip


### PR DESCRIPTION
### Summary
Adds a boolean for nocritical that pairs with underlying nocrit. Allowing a damage's dice to not be doubled on critical. Mostly intended for saves as part of attacks. (Snake poison, etc)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
