### PR TITLE
Add a toggle button for the sidenav on smaller screens

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,10 +1,21 @@
-<mat-sidenav-container class="sidenav-container">
+<!-- Side Menu Floating Button -->
+<button mat-icon-button 
+  *ngIf="(small || mobile) && !sidenav.opened" 
+  (click)="sidenav.toggle()"
+  class="small-menu-button mat-fab"
+  color="accent">
+  <mat-icon>double_arrow</mat-icon>
+</button>
+
+<mat-sidenav-container class="sidenav-container"
+  [ngClass]="{'side-menu-open': !sidenav.opened}">
+
   <mat-sidenav
-    opened
-    mode="side"
+    #sidenav
+    [(opened)]="medium"
+    [mode]="small || mobile ? 'over' : 'side'"
     class="sidenav mat-elevation-z3"
-    fixedTopGap="56px"
-    disableClose="true">
+    fixedTopGap="56px">
     <mat-nav-list>
       <a mat-list-item [routerLink]="['characters']">Characters</a>
 

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,14 +1,14 @@
 <!-- Side Menu Floating Button -->
-<button mat-icon-button 
-  *ngIf="(small || mobile) && !sidenav.opened" 
-  (click)="sidenav.toggle()"
-  class="small-menu-button mat-fab"
-  color="accent">
+<button mat-icon-button
+        *ngIf="(small || mobile) && !sidenav.opened"
+        (click)="sidenav.toggle()"
+        class="small-menu-button mat-fab"
+        color="accent">
   <mat-icon>double_arrow</mat-icon>
 </button>
 
 <mat-sidenav-container class="sidenav-container"
-  [ngClass]="{'side-menu-open': !sidenav.opened}">
+                       [ngClass]="{'side-menu-open': !sidenav.opened}">
 
   <mat-sidenav
     #sidenav

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -43,7 +43,7 @@ mat-sidenav-content {
   padding-left: 4px;
 }
 
-::ng-deep .small-menu-button > span { 
+::ng-deep .small-menu-button > span {
   padding: 0 !important;
 }
 

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -43,8 +43,17 @@ mat-sidenav-content {
   padding-left: 4px;
 }
 
-@media only screen and (max-width: 840px) {
-  .sidenav {
-    width: 150px;
-  }
+::ng-deep .small-menu-button > span { 
+  padding: 0 !important;
+}
+
+.small-menu-button {
+  position: sticky;
+  top: 100px;
+  left: 17px;
+  z-index: 5;
+}
+
+.side-menu-open {
+  margin-top: -40px;
 }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -2,15 +2,18 @@ import {Component} from '@angular/core';
 import {Router} from '@angular/router';
 import {isLoggedIn, removeToken} from '../SecurityHelper';
 import {DashboardService} from './dashboard.service';
+import {BreakpointBaseComponent} from '../shared/breakpoints';
+import {BreakpointObserver} from '@angular/cdk/layout';
 
 @Component({
   selector: 'avr-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss']
 })
-export class DashboardComponent {
+export class DashboardComponent extends BreakpointBaseComponent {
 
-  constructor(private router: Router, private dashboardService: DashboardService) {
+  constructor(private router: Router, private dashboardService: DashboardService, private bp: BreakpointObserver) {
+    super(bp);
     if (!isLoggedIn()) {
       this.router.navigate(['login']);
     }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,9 +1,9 @@
+import {BreakpointObserver} from '@angular/cdk/layout';
 import {Component} from '@angular/core';
 import {Router} from '@angular/router';
 import {isLoggedIn, removeToken} from '../SecurityHelper';
-import {DashboardService} from './dashboard.service';
 import {BreakpointBaseComponent} from '../shared/breakpoints';
-import {BreakpointObserver} from '@angular/cdk/layout';
+import {DashboardService} from './dashboard.service';
 
 @Component({
   selector: 'avr-dashboard',


### PR DESCRIPTION
### Summary
This adds a sticky button to toggle open the side nav on smaller screens, as opposed to always having it open (and slightly reducing the size). This should help make using the dashboard on mobile devices a little bit easier.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
