### PR TITLE
2021w49: Refactor HB to use APIResponse, display 403s in sharing, IEffect parenting

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import {AutomationEditorModule} from './shared/automation-editor/automation-edit
 import {DialogsModule} from './shared/dialogs/dialogs.module';
 import {DiscordEmbedModule} from './shared/discord-embed/discord-embed.module';
 import {registerDraconicLanguage} from './shared/monacoDraconic';
+import {ValidationSnackbar} from './shared/validation-snackbar/validation-snackbar.component';
 import {ThemesModule} from './themes/themes.module';
 
 Sentry.init({dsn: 'https://af2b06560981446bb55f64b6f79fd520@sentry.io/1486249'});
@@ -59,6 +60,7 @@ const monacoConfig = {
     ErrorComponent,
     CommandsComponent,
     CommandDisplayComponent,
+    ValidationSnackbar,
   ],
   imports: [
     BrowserModule.withServerTransition({appId: 'serverApp'}),

--- a/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.ts
+++ b/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.ts
@@ -151,7 +151,13 @@ export class AttackEditorDialog implements OnInit {
           if (result.success) {
             dialogRef.close(data);
           } else {
-            dialogRef.componentInstance.error = result.error;
+            this.snackBar.openFromComponent(ValidationSnackbar, {
+              data: {
+                html: `${result.error}`
+              },
+              horizontalPosition: 'right',
+              duration: -1
+            });
           }
         }
       );

--- a/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.ts
+++ b/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.ts
@@ -6,8 +6,10 @@ import {Attack, CharacterMeta} from '../../../schemas/Character';
 import {JSONExportDialog} from '../../../shared/dialogs/json-export-dialog/json-export-dialog.component';
 import {JSONImportDialog} from '../../../shared/dialogs/json-import-dialog/json-import-dialog.component';
 import {SRDCopyDialog} from '../../../shared/dialogs/srd-copy-dialog/srd-copy-dialog.component';
+import {ValidationSnackbar} from '../../../shared/validation-snackbar/validation-snackbar.component';
 import {ApiResponse} from '../../APIHelper';
 import {DashboardService} from '../../dashboard.service';
+import {MatSnackBar} from '@angular/material/snack-bar';
 
 @Component({
   selector: 'avr-attack-editor-dialog',
@@ -26,7 +28,12 @@ export class AttackEditorDialog implements OnInit {
   showAdvancedOptions = false;
 
   constructor(@Inject(MAT_DIALOG_DATA) public character: CharacterMeta, private charService: DashboardService,
-              private dialogRef: MatDialogRef<AttackEditorDialog>, private dialog: MatDialog) {
+              private dialogRef: MatDialogRef<AttackEditorDialog>, private dialog: MatDialog, private snackBar: MatSnackBar) {
+  }
+
+
+  ngOnDestroy() {
+    this.snackBar.dismiss();
   }
 
   ngOnInit() {
@@ -81,8 +88,13 @@ export class AttackEditorDialog implements OnInit {
         this.saveButtonDisabled = false;
 
         if (!result || result.error) {
-          // failed PUT, display error... somewhere
-          this.errorValue = result?.error || 'Failed to save attacks.';
+          this.snackBar.openFromComponent(ValidationSnackbar, {
+            data: {
+              html: `${result.error}`
+            },
+            horizontalPosition: 'right',
+            duration: -1
+          });
         } else {
           this.errorValue = null;
         }

--- a/src/app/dashboard/homebrew/homebrew.service.ts
+++ b/src/app/dashboard/homebrew/homebrew.service.ts
@@ -1,11 +1,11 @@
-import {HttpClient, HttpResponse} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {catchError, map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 import {environment} from '../../../environments/environment';
 import {Item, Pack} from '../../schemas/homebrew/Items';
 import {Spell, Tome} from '../../schemas/homebrew/Spells';
-import {ApiResponse, defaultOptions, defaultTextErrorHandler, defaultTextOptions} from '../APIHelper';
+import {ApiResponse, defaultErrorHandler, defaultOptions} from '../APIHelper';
 
 const itemsUrl = `${environment.apiURL}/homebrew/items`;
 const spellsUrl = `${environment.apiURL}/homebrew/spells`;
@@ -19,101 +19,91 @@ export class HomebrewService {
   }
 
   /* -----PACKS----- */
-  getUserPacks(): Observable<Pack[]> {
-    return this.http.get<Pack[]>(`${itemsUrl}/me`, defaultOptions());
+  getUserPacks(): Observable<ApiResponse<Pack[]>> {
+    return this.http.get<ApiResponse<Pack[]>>(`${itemsUrl}/me`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  newPack(pack: { name: string, public: boolean, desc: string, image: string }): Observable<any> {
-    return this.http.post<any>(`${itemsUrl}`, pack, defaultOptions())
-      .pipe(
-        catchError(this.handleError('newPack'))
-      );
+  newPack(pack: { name: string, public: boolean, desc: string, image: string }): Observable<ApiResponse<{ packId: string }>> {
+    return this.http.post<ApiResponse<{ packId: string }>>(`${itemsUrl}`, pack, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getPack(id): Observable<Pack> {
-    return this.http.get<Pack>(`${itemsUrl}/${id}`, defaultOptions());
+  getPack(id): Observable<ApiResponse<Pack>> {
+    return this.http.get<ApiResponse<Pack>>(`${itemsUrl}/${id}`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
   putPack(pack: Pack): Observable<ApiResponse<string>> {
-    return this.http.put<string>(`${itemsUrl}/${pack._id.$oid}`, pack, defaultTextOptions({observe: 'response'}))
-      .pipe(
-        map((resp: HttpResponse<string>) => {
-          return {success: resp.ok, data: resp.body, status: resp.status} as ApiResponse<string>;
-        }),
-        catchError(defaultTextErrorHandler)
-      );
-  }
-
-  deletePack(pack: Pack): Observable<string> {
     // @ts-ignore
-    return this.http.delete<string>(`${itemsUrl}/${pack._id.$oid}`, defaultTextOptions())
-      .pipe(
-        catchError(this.handleError('deletePack'))
-      );
+    return this.http.put<ApiResponse<string>>(`${itemsUrl}/${pack._id}`, pack, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getPackEditors(id: string): Observable<string[]> {
-    return this.http.get<string[]>(`${itemsUrl}/${id}/editors`, defaultOptions());
+  deletePack(pack: Pack): Observable<ApiResponse<string>> {
+    // @ts-ignore
+    return this.http.delete<ApiResponse<string>>(`${itemsUrl}/${pack._id}`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getTemplateItems(): Observable<Item[]> {
-    return this.http.get<Item[]>(`${itemsUrl}/srd`, defaultOptions());
+  updatePackSharing(id: string, isPublic: boolean): Observable<ApiResponse<string>> {
+    return this.http.patch<ApiResponse<string>>(`${itemsUrl}/${id}/sharing`, {public: isPublic}, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
+  }
+
+  getPackEditors(id: string): Observable<ApiResponse<string[]>> {
+    return this.http.get<ApiResponse<string[]>>(`${itemsUrl}/${id}/editors`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
+  }
+
+  getTemplateItems(): Observable<ApiResponse<Item[]>> {
+    return this.http.get<ApiResponse<Item[]>>(`${itemsUrl}/srd`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
   /* -----TOMES----- */
-  getUserTomes(): Observable<Tome[]> {
-    return this.http.get<Tome[]>(`${spellsUrl}/me`, defaultOptions());
+  getUserTomes(): Observable<ApiResponse<Tome[]>> {
+    return this.http.get<ApiResponse<Tome[]>>(`${spellsUrl}/me`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  newTome(tome: { name: string, public: boolean, desc: string, image: string }): Observable<any> {
-    return this.http.post<any>(`${spellsUrl}`, tome, defaultOptions())
-      .pipe(
-        catchError(this.handleError('newTome'))
-      );
+  newTome(tome: { name: string, public: boolean, desc: string, image: string }): Observable<ApiResponse<{ tomeId: string }>> {
+    return this.http.post<ApiResponse<{ tomeId: string }>>(`${spellsUrl}`, tome, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getTome(id): Observable<Tome> {
-    return this.http.get<Tome>(`${spellsUrl}/${id}`, defaultOptions());
+  getTome(id): Observable<ApiResponse<Tome>> {
+    return this.http.get<ApiResponse<Tome>>(`${spellsUrl}/${id}`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
   putTome(tome: Tome): Observable<ApiResponse<string>> {
-    return this.http.put<string>(`${spellsUrl}/${tome._id.$oid}`, tome, defaultTextOptions({observe: 'response'}))
-      .pipe(
-        map((resp: HttpResponse<string>) => {
-          return {success: resp.ok, data: resp.body, status: resp.status} as ApiResponse<string>;
-        }),
-        catchError(defaultTextErrorHandler)
-      );
+    return this.http.put<ApiResponse<string>>(`${spellsUrl}/${tome._id}`, tome, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  deleteTome(tome: Tome): Observable<string> {
-    // @ts-ignore
-    return this.http.delete<string>(`${spellsUrl}/${tome._id.$oid}`, defaultTextOptions())
-      .pipe(
-        catchError(this.handleError('deleteTome'))
-      );
+  deleteTome(tome: Tome): Observable<ApiResponse<string>> {
+    return this.http.delete<ApiResponse<string>>(`${spellsUrl}/${tome._id}`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getTomeEditors(id: string): Observable<string[]> {
-    return this.http.get<string[]>(`${spellsUrl}/${id}/editors`, defaultOptions());
+  updateTomeSharing(id: string, isPublic: boolean): Observable<ApiResponse<string>> {
+    return this.http.patch<ApiResponse<string>>(`${spellsUrl}/${id}/sharing`, {public: isPublic}, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getTemplateSpells(): Observable<Spell[]> {
-    return this.http.get<Spell[]>(`${spellsUrl}/srd`, defaultOptions());
+  getTomeEditors(id: string): Observable<ApiResponse<string[]>> {
+    return this.http.get<ApiResponse<string[]>>(`${spellsUrl}/${id}/editors`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  validateSpellJSON(data: object): Observable<{ success: boolean, result: string }> {
-    return this.http.post<{ success: boolean, result: string }>(`${spellsUrl}/validate`, data, defaultOptions())
-      .pipe(
-        catchError(err => of({success: false, result: err.error}))
-      );
+  getTemplateSpells(): Observable<ApiResponse<Spell[]>> {
+    return this.http.get<ApiResponse<Spell[]>>(`${spellsUrl}/srd`, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  /* -----META----- */
-  private handleError<T>(operation = 'operation') {
-    return (error: any): Observable<object> => {
-      console.error(error); // log to console and hope for the best
-      return of({error: `${operation} failed: ${error.error}`, success: false});
-    };
+  validateSpellJSON(data: object): Observable<ApiResponse<{ success: boolean, result: string }>> {
+    return this.http.post<ApiResponse<{ success: boolean, result: string }>>(`${spellsUrl}/validate`, data, defaultOptions())
+      .pipe(catchError(defaultErrorHandler));
   }
 }

--- a/src/app/dashboard/homebrew/items/items.component.html
+++ b/src/app/dashboard/homebrew/items/items.component.html
@@ -21,7 +21,7 @@
         </p>
       </mat-card-content>
       <mat-card-actions>
-        <a mat-button routerLink="{{pack._id.$oid}}">EDIT</a>
+        <a mat-button routerLink="{{pack._id}}">EDIT</a>
         <button mat-button (click)="beginShare(pack)">SHARE</button>
       </mat-card-actions>
     </mat-card>

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.html
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.html
@@ -79,6 +79,9 @@
   <div class="container">
     <mat-card>
       <mat-spinner [diameter]="24"></mat-spinner>
+      <p class="mat-error" *ngIf="error">
+        {{error}}
+      </p>
     </mat-card>
   </div>
 </div>

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.ts
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.ts
@@ -9,6 +9,7 @@ import {Item, Pack, REQUIRED_ITEM_PROPS} from '../../../../schemas/homebrew/Item
 import {UserInfo} from '../../../../schemas/UserInfo';
 import {JSONImportDialog} from '../../../../shared/dialogs/json-import-dialog/json-import-dialog.component';
 import {SRDCopyDialog} from '../../../../shared/dialogs/srd-copy-dialog/srd-copy-dialog.component';
+import {ValidationSnackbar} from '../../../../shared/validation-snackbar/validation-snackbar.component';
 import {getUser} from '../../../APIHelper';
 import {DashboardService} from '../../../dashboard.service';
 import {HomebrewService} from '../../homebrew.service';
@@ -204,10 +205,12 @@ export class PackDetailComponent implements OnInit, OnDestroy {
         if (result.success) {
           this.snackBar.open(`${result.data} Use "!pack ${this.pack.name}" to activate the pack in Discord!`, null, {horizontalPosition: 'right'});
         } else {
-          this.snackBar.open(`Error: ${result.error}`, 'Close', {
+          this.snackBar.openFromComponent(ValidationSnackbar, {
+            data: {
+              html: `${result.error}`
+            },
             horizontalPosition: 'right',
-            duration: -1,
-            panelClass: 'preserve-whitespace'
+            duration: -1
           });
         }
       });
@@ -218,11 +221,14 @@ export class PackDetailComponent implements OnInit, OnDestroy {
     this.homebrewService.deletePack(this.pack)
       .subscribe(result => {
         if (!result.success) {
-          this.snackBar.open(`Error: ${result.error}`, 'Close', {
+          this.snackBar.openFromComponent(ValidationSnackbar, {
+            data: {
+              html: `${result.error}`
+            },
             horizontalPosition: 'right',
-            duration: -1,
-            panelClass: 'preserve-whitespace'
-          });
+            duration: -1
+          }
+          );
         } else {
           this.router.navigate(['../'], {relativeTo: this.route});
         }

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.ts
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.ts
@@ -4,6 +4,7 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {ActivatedRoute, Router} from '@angular/router';
+import {map} from 'rxjs/operators';
 import {Item, Pack, REQUIRED_ITEM_PROPS} from '../../../../schemas/homebrew/Items';
 import {UserInfo} from '../../../../schemas/UserInfo';
 import {JSONImportDialog} from '../../../../shared/dialogs/json-import-dialog/json-import-dialog.component';
@@ -27,6 +28,7 @@ export class PackDetailComponent implements OnInit, OnDestroy {
   isOwner: boolean;
   changesOpen = false;
   selectedItem: Item;
+  error: string;
 
   constructor(private route: ActivatedRoute, private homebrewService: HomebrewService,
               private dashboardService: DashboardService, private location: Location, private dialog: MatDialog,
@@ -44,9 +46,13 @@ export class PackDetailComponent implements OnInit, OnDestroy {
   getPack() {
     const id = this.route.snapshot.paramMap.get('pack');
     this.homebrewService.getPack(id)
-      .subscribe(pack => {
-        this.pack = pack;
-        this.calcCanEdit();
+      .subscribe(response => {
+        if (response.success) {
+          this.pack = response.data;
+          this.calcCanEdit();
+        } else {
+          this.error = response.error;
+        }
       });
   }
 
@@ -58,9 +64,15 @@ export class PackDetailComponent implements OnInit, OnDestroy {
     if (this.isOwner) {
       this.canEdit = true;
     } else {
-      const id = this.pack._id.$oid;
+      const id = this.pack._id;
       this.homebrewService.getPackEditors(id)
-        .subscribe(editors => this.canEdit = editors.some(e => e === this.user.id));
+        .subscribe(response => {
+          if (response.success) {
+            this.canEdit = response.data.some(e => e === this.user.id);
+          } else {
+            this.error = response.error;
+          }
+        });
     }
   }
 
@@ -147,7 +159,10 @@ export class PackDetailComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(SRDCopyDialog, {
       width: '60%',
       disableClose: true,
-      data: {getter: () => this.homebrewService.getTemplateItems(), namer: a => a.name}
+      data: {
+        getter: () => this.homebrewService.getTemplateItems().pipe(map((value) => value.data)),
+        namer: a => a.name
+      }
     });
 
     dialogRef.afterClosed().subscribe(result => {
@@ -202,8 +217,15 @@ export class PackDetailComponent implements OnInit, OnDestroy {
     // HTTP DELETE /homebrew/items/:pack
     this.homebrewService.deletePack(this.pack)
       .subscribe(result => {
-        console.log(result);
-        this.router.navigate(['../'], {relativeTo: this.route});
+        if (!result.success) {
+          this.snackBar.open(`Error: ${result.error}`, 'Close', {
+            horizontalPosition: 'right',
+            duration: -1,
+            panelClass: 'preserve-whitespace'
+          });
+        } else {
+          this.router.navigate(['../'], {relativeTo: this.route});
+        }
       });
   }
 

--- a/src/app/dashboard/homebrew/items/pack-share-dialog/pack-share-dialog.component.ts
+++ b/src/app/dashboard/homebrew/items/pack-share-dialog/pack-share-dialog.component.ts
@@ -26,7 +26,7 @@ export class PackShareDialog implements OnInit {
   constructor(@Inject(MAT_DIALOG_DATA) public data: Pack, private dialog: MatDialog,
               private hbService: HomebrewService, private discord: DiscordService) {
     this.public = data.public;
-    this.shareLink = `https://avrae.io/homebrew/items/${data._id.$oid}`;
+    this.shareLink = `https://avrae.io/homebrew/items/${data._id}`;
     this.loaded = data.items !== undefined;
   }
 
@@ -39,20 +39,26 @@ export class PackShareDialog implements OnInit {
   }
 
   loadItems() {
-    const id = this.data._id.$oid;
+    const id = this.data._id;
     this.hbService.getPack(id)
-      .subscribe(pack => {
-        this.data = pack;
+      .subscribe(response => {
+        if (!response.success) {
+          return;
+        }
+        this.data = response.data;
         this.loaded = true;
       });
   }
 
   loadEditors() {
-    const id = this.data._id.$oid;
+    const id = this.data._id;
     this.hbService.getPackEditors(id)
-      .subscribe(editors => {
+      .subscribe(response => {
+        if (!response.success) {
+          return;
+        }
         const out = [];
-        editors.forEach(eid => out.push(this.discord.getUser(eid)));
+        response.data.forEach(eid => out.push(this.discord.getUser(eid)));
         this.editors = out;
       });
   }
@@ -76,5 +82,4 @@ export class PackShareDialog implements OnInit {
       width: '60%'
     });
   }
-
 }

--- a/src/app/dashboard/homebrew/spells/dialogs/tome-share-dialog.component.ts
+++ b/src/app/dashboard/homebrew/spells/dialogs/tome-share-dialog.component.ts
@@ -25,7 +25,7 @@ export class TomeShareDialog implements OnInit {
   constructor(@Inject(MAT_DIALOG_DATA) public data: Tome, private dialog: MatDialog,
               private hbService: HomebrewService, private discord: DiscordService) {
     this.public = data.public;
-    this.shareLink = `https://avrae.io/homebrew/spells/${data._id.$oid}`;
+    this.shareLink = `https://avrae.io/homebrew/spells/${data._id}`;
     this.loaded = data.spells !== undefined;
   }
 
@@ -38,20 +38,23 @@ export class TomeShareDialog implements OnInit {
   }
 
   loadEditors() {
-    const id = this.data._id.$oid;
+    const id = this.data._id;
     this.hbService.getTomeEditors(id)
-      .subscribe(editors => {
+      .subscribe(response => {
         const out = [];
-        editors.forEach(eid => out.push(this.discord.getUser(eid)));
+        response.data.forEach(eid => out.push(this.discord.getUser(eid)));
         this.editors = out;
       });
   }
 
   loadSpells() {
-    const id = this.data._id.$oid;
+    const id = this.data._id;
     this.hbService.getTome(id)
-      .subscribe(tome => {
-        this.data = tome;
+      .subscribe(response => {
+        if (!response.success) {
+          return;
+        }
+        this.data = response.data;
         this.loaded = true;
       });
   }

--- a/src/app/dashboard/homebrew/spells/spells.component.html
+++ b/src/app/dashboard/homebrew/spells/spells.component.html
@@ -21,7 +21,7 @@
         </p>
       </mat-card-content>
       <mat-card-actions>
-        <a mat-button routerLink="{{tome._id.$oid}}">EDIT</a>
+        <a mat-button routerLink="{{tome._id}}">EDIT</a>
         <button mat-button (click)="beginShare(tome)">SHARE</button>
       </mat-card-actions>
     </mat-card>

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.ts
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.ts
@@ -1,6 +1,7 @@
 import {moveItemInArray} from '@angular/cdk/drag-drop';
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {map} from 'rxjs/operators';
 import {Spell, Tome} from '../../../../../schemas/homebrew/Spells';
 import {UserInfo} from '../../../../../schemas/UserInfo';
 import {JSONImportDialog} from '../../../../../shared/dialogs/json-import-dialog/json-import-dialog.component';
@@ -59,7 +60,7 @@ export class SpellListComponent implements OnInit {
     const dialogRef = this.dialog.open(SRDCopyDialog, {
       width: '60%',
       disableClose: true,
-      data: {getter: () => this.hbService.getTemplateSpells(), namer: a => a.name}
+      data: {getter: () => this.hbService.getTemplateSpells().pipe(map(value => value.data)), namer: a => a.name}
     });
 
     dialogRef.afterClosed().subscribe(result => {
@@ -84,7 +85,7 @@ export class SpellListComponent implements OnInit {
           if (result.success) {
             dialogRef.close(data);
           } else {
-            dialogRef.componentInstance.error = result.result;
+            dialogRef.componentInstance.error = result.error;
           }
         }
       );

--- a/src/app/dashboard/homebrew/spells/tome-detail/tome-detail.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/tome-detail.component.html
@@ -37,6 +37,9 @@
   <div class="container">
     <mat-card>
       <mat-spinner [diameter]="24"></mat-spinner>
+      <p class="mat-error" *ngIf="error">
+        {{error}}
+      </p>
     </mat-card>
   </div>
 </div>

--- a/src/app/dashboard/homebrew/spells/tome-detail/tome-detail.component.ts
+++ b/src/app/dashboard/homebrew/spells/tome-detail/tome-detail.component.ts
@@ -11,6 +11,8 @@ import {DashboardService} from '../../../dashboard.service';
 import {HomebrewService} from '../../homebrew.service';
 import {TomeOptionsDialog} from '../dialogs/tome-options-dialog.component';
 import {TomeShareDialog} from '../dialogs/tome-share-dialog.component';
+import {ValidationSnackbar} from '../../../../shared/validation-snackbar/validation-snackbar.component';
+
 
 @Component({
   selector: 'avr-tome-detail',
@@ -122,12 +124,13 @@ export class TomeDetailComponent implements OnInit, OnDestroy {
         if (result.success) {
           this.snackBar.open(`${result.data} Use "!tome ${this.tome.name}" to activate the pack in Discord!`, null, {horizontalPosition: 'right'});
         } else {
-          console.log(result);
-          this.snackBar.open(`Error: ${result.error}`, 'Close', {
+          this.snackBar.openFromComponent(ValidationSnackbar, {
+            data: {
+              html: `${result.error}`
+            },
             horizontalPosition: 'right',
-            duration: -1,
-            panelClass: 'preserve-whitespace'
-          });
+            duration: -1
+          });  
         }
       });
   }
@@ -137,11 +140,15 @@ export class TomeDetailComponent implements OnInit, OnDestroy {
     this.homebrewService.deleteTome(this.tome)
       .subscribe(result => {
         if (!result.success) {
-          this.snackBar.open(`Error: ${result.error}`, 'Close', {
+          this.snackBar.openFromComponent(ValidationSnackbar, {
+            data: {
+              html: `${result.error}`
+            },
             horizontalPosition: 'right',
             duration: -1,
-            panelClass: 'preserve-whitespace'
-          });
+            panelClass: ['mat-simple-snackbar']
+          }
+          );
         } else {
           this.router.navigate(['../'], {relativeTo: this.route});
         }

--- a/src/app/dashboard/workshop/collection-edit/collection-edit.component.html
+++ b/src/app/dashboard/workshop/collection-edit/collection-edit.component.html
@@ -148,6 +148,9 @@
 </div>
 
 <div class="content mat-typography" *ngIf="!collection">
-  Loading...
+  <mat-spinner [diameter]="24" *ngIf="!error"></mat-spinner>
+  <p class="mat-error" *ngIf="error">
+    {{error}}
+  </p>
 </div>
 

--- a/src/app/dashboard/workshop/collection/collection.component.html
+++ b/src/app/dashboard/workshop/collection/collection.component.html
@@ -140,6 +140,9 @@
 </div>
 
 <div class="content mat-typography" *ngIf="!collection">
-  Loading...
+  <mat-spinner [diameter]="24" *ngIf="!error"></mat-spinner>
+  <p class="mat-error" *ngIf="error">
+    {{error}}
+  </p>
 </div>
 

--- a/src/app/homebrew-sharing/homebrew-sharing.service.ts
+++ b/src/app/homebrew-sharing/homebrew-sharing.service.ts
@@ -1,7 +1,9 @@
-import {Injectable} from '@angular/core';
-import {environment} from '../../environments/environment';
 import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {environment} from '../../environments/environment';
+import {ApiResponse, defaultErrorHandler} from '../dashboard/APIHelper';
 import {Pack} from '../schemas/homebrew/Items';
 import {Tome} from '../schemas/homebrew/Spells';
 
@@ -16,11 +18,13 @@ export class HomebrewSharingService {
   constructor(private http: HttpClient) {
   }
 
-  getPack(id): Observable<Pack> {
-    return this.http.get<Pack>(`${itemsUrl}/${id}`);
+  getPack(id): Observable<ApiResponse<Pack>> {
+    return this.http.get<ApiResponse<Pack>>(`${itemsUrl}/${id}`)
+      .pipe(catchError(defaultErrorHandler));
   }
 
-  getTome(id): Observable<Tome> {
-    return this.http.get<Tome>(`${spellsUrl}/${id}`);
+  getTome(id): Observable<ApiResponse<Tome>> {
+    return this.http.get<ApiResponse<Tome>>(`${spellsUrl}/${id}`)
+      .pipe(catchError(defaultErrorHandler));
   }
 }

--- a/src/app/homebrew-sharing/pack-share/pack-share.component.html
+++ b/src/app/homebrew-sharing/pack-share/pack-share.component.html
@@ -54,8 +54,8 @@
   <div class="container">
     <mat-card>
       <mat-spinner [diameter]="24"></mat-spinner>
-      <p>
-        If this is taking too long to load, you may not have permissions to view this pack.
+      <p class="mat-error" *ngIf="error">
+        {{error}}
       </p>
     </mat-card>
   </div>

--- a/src/app/homebrew-sharing/pack-share/pack-share.component.ts
+++ b/src/app/homebrew-sharing/pack-share/pack-share.component.ts
@@ -17,6 +17,7 @@ export class PackShareComponent implements OnInit {
   pack: Pack;
   owner: DiscordUser;
   selectedItem: Item;
+  error: string;
 
   constructor(private route: ActivatedRoute, private homebrewService: HomebrewSharingService, private discord: DiscordService,
               private meta: Meta) {
@@ -51,10 +52,14 @@ export class PackShareComponent implements OnInit {
   getPack() {
     const id = this.route.snapshot.paramMap.get('pack');
     this.homebrewService.getPack(id)
-      .subscribe(pack => {
-        this.pack = pack;
-        this.getOwner();
-        this.updateMeta();
+      .subscribe(response => {
+        if (response.success) {
+          this.pack = response.data;
+          this.getOwner();
+          this.updateMeta();
+        } else {
+          this.error = response.error;
+        }
       });
   }
 

--- a/src/app/homebrew-sharing/tome-share/tome-share.component.html
+++ b/src/app/homebrew-sharing/tome-share/tome-share.component.html
@@ -50,8 +50,8 @@
   <div class="container">
     <mat-card>
       <mat-spinner [diameter]="24"></mat-spinner>
-      <p>
-        If this is taking too long to load, you may not have permissions to view this tome.
+      <p class="mat-error" *ngIf="error">
+        {{error}}
       </p>
     </mat-card>
   </div>

--- a/src/app/homebrew-sharing/tome-share/tome-share.component.ts
+++ b/src/app/homebrew-sharing/tome-share/tome-share.component.ts
@@ -17,6 +17,7 @@ export class TomeShareComponent implements OnInit {
   tome: Tome;
   owner: DiscordUser;
   selectedSpell: Spell;
+  error: string;
 
   constructor(private route: ActivatedRoute, private homebrewService: HomebrewSharingService, private discord: DiscordService,
               private meta: Meta) {
@@ -56,10 +57,14 @@ export class TomeShareComponent implements OnInit {
   getTome() {
     const id = this.route.snapshot.paramMap.get('tome');
     this.homebrewService.getTome(id)
-      .subscribe(tome => {
-        this.tome = tome;
-        this.getOwner();
-        this.updateMeta();
+      .subscribe(response => {
+        if (response.success) {
+          this.tome = response.data;
+          this.getOwner();
+          this.updateMeta();
+        } else {
+          this.error = response.error;
+        }
       });
   }
 

--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -96,8 +96,10 @@ export class IEffect extends AutomationEffect {
   conc?: boolean;
   desc?: AnnotatedString;
   stacking?: boolean;
+  save_as?: string;
+  parent?: string;
 
-  constructor(name = '', duration = '', effects = '', desc = '', end = false, conc = false, stacking=false, meta?) {
+  constructor(name = '', duration = '', effects = '', desc = '', end = false, conc = false, stacking = false, save_as = null, parent = null, meta?) {
     super('ieffect', meta);
     this.name = name;
     this.duration = duration;
@@ -105,6 +107,8 @@ export class IEffect extends AutomationEffect {
     this.end = end;
     this.desc = desc;
     this.stacking = stacking;
+    this.save_as = save_as;
+    this.parent = parent;
   }
 }
 

--- a/src/app/schemas/homebrew/Items.ts
+++ b/src/app/schemas/homebrew/Items.ts
@@ -1,5 +1,3 @@
-import {DiscordUser} from '../Discord';
-
 export const REQUIRED_ITEM_PROPS = ['name'];
 
 export class Pack {
@@ -10,7 +8,7 @@ export class Pack {
   image: string;
   items?: Item[];
   numItems?: number;
-  _id: { '$oid': string };
+  _id: string;
 }
 
 export class Item {

--- a/src/app/schemas/homebrew/Spells.ts
+++ b/src/app/schemas/homebrew/Spells.ts
@@ -12,7 +12,7 @@ export class Tome {
   image: string;
   spells?: Spell[];
   numSpells?: number;
-  _id: { '$oid': string };
+  _id: string;
 }
 
 export class Spell {

--- a/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
@@ -6,11 +6,11 @@ import {EffectComponent} from '../shared/EffectComponent';
   selector: 'avr-attack-effect',
   template: `
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-checkbox [(ngModel)]="custom" (change)="changed.emit(); onCustomChange()">
+      <mat-checkbox [(ngModel)]="custom" (change)="changed.emit(); onCustomChange()" *ngIf="spell != null">
         Has custom attack bonus
       </mat-checkbox>
       <mat-form-field *ngIf="custom">
-        <input matInput placeholder="Custom Bonus" (change)="changed.emit()" [(ngModel)]="effect.attackBonus">
+        <input matInput placeholder="Attack Bonus" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.attackBonus">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
@@ -66,7 +66,7 @@ export class AttackEffectComponent extends EffectComponent<Attack> implements On
 
   onCustomChange() {
     if (!this.custom) {
-      this.effect.attackBonus = '';
+      this.effect.attackBonus = undefined;
     }
   }
 

--- a/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.ts
@@ -7,7 +7,7 @@ import {EffectComponent} from '../shared/EffectComponent';
   template: `
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
       <mat-form-field>
-        <input matInput placeholder="Condition" (change)="changed.emit()" [(ngModel)]="effect.condition">
+        <input matInput placeholder="Condition" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.condition" required>
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
 

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
@@ -25,14 +25,15 @@ import {EffectComponent} from '../shared/EffectComponent';
         <span *ngSwitchDefault>
           <span> named </span>
           <mat-form-field>
-            <input matInput placeholder="Counter Name" (change)="changed.emit()" [(ngModel)]="effect.counter">
+            <input matInput placeholder="Counter Name" (change)="changed.emit()" [(ngModel)]="effect.counter" required>
           </mat-form-field>
         </span>
 
         <span *ngSwitchCase="'slot'">
           <span> of level </span>
           <mat-form-field>
-            <input matInput placeholder="Slot Level" (change)="changed.emit()" [(ngModel)]="effect.counter.slot">
+            <input matInput placeholder="Slot Level" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.counter.slot"
+                   required>
             <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
           </mat-form-field>
         </span>
@@ -60,7 +61,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 
     <div>
       <mat-form-field>
-        <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount">
+        <input matInput placeholder="Amount" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.amount" required>
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
 

--- a/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
@@ -5,16 +5,19 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-damage-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-form-field>
-        <input matInput placeholder="Damage" (change)="changed.emit()" [(ngModel)]="effect.damage">
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Damage" (change)="changed.emit()" [(ngModel)]="effect.damage" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
       <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
         Allow Overheal
       </mat-checkbox>
-      <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
-      <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+      <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
+      <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip
       </mat-checkbox>
     </div>

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
@@ -6,6 +6,6 @@
   width: 100%;
 }
 
-.input-monospace {
+.text-monospace {
   font-family: "Source Code Pro", monospace;
 }

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
@@ -5,3 +5,7 @@
 .wide {
   width: 100%;
 }
+
+.input-monospace {
+  font-family: "Source Code Pro", monospace;
+}

--- a/src/app/shared/automation-editor/effect-editor/higher-level/higher-level.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/higher-level/higher-level.component.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
-import {Damage, Roll, SetVariable} from '../../../../schemas/homebrew/AutomationEffects';
+import {Damage, Roll, SetVariable, TempHP} from '../../../../schemas/homebrew/AutomationEffects';
 import {Spell} from '../../../../schemas/homebrew/Spells';
 
 const range = (start, end) => Array.from({length: (end - start)}, (v, k) => k + start);
@@ -30,7 +30,7 @@ const range = (start, end) => Array.from({length: (end - start)}, (v, k) => k + 
 })
 export class HigherLevelComponent implements OnInit, OnChanges {
 
-  @Input() parent: Damage | Roll | SetVariable;
+  @Input() parent: Damage | Roll | TempHP | SetVariable;
   @Input() spell: Spell;
   @Output() changed = new EventEmitter();
 

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
@@ -7,10 +7,10 @@ import {EffectComponent} from '../shared/EffectComponent';
   template: `
     <div fxLayout="row" fxLayoutGap="4px">
       <mat-form-field fxFlex="1 2 auto">
-        <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name">
+        <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name" required>
       </mat-form-field>
       <mat-form-field fxFlex="1 2 auto">
-        <input matInput placeholder="Duration" (change)="changed.emit()" [(ngModel)]="effect.duration"
+        <input matInput placeholder="Duration" (change)="changed.emit()" [(ngModel)]="effect.duration" required
                matTooltip="Use -1 for infinite duration.">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
@@ -19,10 +19,11 @@ import {EffectComponent} from '../shared/EffectComponent';
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
     </div>
+
     <div fxLayout="row" fxLayoutGap="8px">
       <mat-checkbox [(ngModel)]="effect.end" (change)="changed.emit();"
                     matTooltip="Whether the effect duration ticks down at the end of the turn rather than the start.">
-        Ticks on end?
+        Ticks on end of turn?
       </mat-checkbox>
       <mat-checkbox [(ngModel)]="effect.conc" (change)="changed.emit();">
         Requires concentration?
@@ -32,11 +33,23 @@ import {EffectComponent} from '../shared/EffectComponent';
         Stacking?
       </mat-checkbox>
     </div>
+
     <div fxLayout="row">
       <mat-form-field class="wide">
         <textarea matInput placeholder="Description" rows="3" (change)="changed.emit()"
                   [(ngModel)]="effect.desc" maxlength="500"></textarea>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
+      </mat-form-field>
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="8px">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Save As" class="input-monospace" (change)="changed.emit()" [(ngModel)]="effect.save_as"
+               matTooltip="If supplied, saves the added effect as an automation variable. Use this in another IEffect's parent field to set this effect as its parent.">
+      </mat-form-field>
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Parent" class="input-monospace" (change)="changed.emit()" [(ngModel)]="effect.parent"
+               matTooltip="If supplied, sets the added effect's parent to the given effect. This must be the same as another IEffect's save_as.">
       </mat-form-field>
     </div>
   `,

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
@@ -44,11 +44,11 @@ import {EffectComponent} from '../shared/EffectComponent';
 
     <div fxLayout="row" fxLayoutGap="8px">
       <mat-form-field fxFlex>
-        <input matInput placeholder="Save As" class="input-monospace" (change)="changed.emit()" [(ngModel)]="effect.save_as"
+        <input matInput placeholder="Save As" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.save_as"
                matTooltip="If supplied, saves the added effect as an automation variable. Use this in another IEffect's parent field to set this effect as its parent.">
       </mat-form-field>
       <mat-form-field fxFlex>
-        <input matInput placeholder="Parent" class="input-monospace" (change)="changed.emit()" [(ngModel)]="effect.parent"
+        <input matInput placeholder="Parent" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.parent"
                matTooltip="If supplied, sets the added effect's parent to the given effect. This must be the same as another IEffect's save_as.">
       </mat-form-field>
     </div>

--- a/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
@@ -5,20 +5,25 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-roll-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-form-field>
-        <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name">
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center">
+      <mat-form-field fxFlex="1 3 auto">
+        <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name" required
+               matTooltip="The result of the roll will be saved to an automation variable with this name.">
       </mat-form-field>
-      <mat-form-field>
-        <input matInput placeholder="Dice" (change)="changed.emit()" [(ngModel)]="effect.dice">
+      <mat-form-field fxFlex="3 1 auto">
+        <input matInput placeholder="Dice" (change)="changed.emit()" [(ngModel)]="effect.dice" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
-      <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
-      <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
-        Scales like Cantrip
-      </mat-checkbox>
-      <mat-checkbox [(ngModel)]="effect.hidden" (change)="changed.emit()">
+      <mat-checkbox [(ngModel)]="effect.hidden" (change)="changed.emit()"
+                    matTooltip="If checked, the roll won't display in the automation's Meta field or apply bonuses from the -d argument.">
         Hidden
+      </mat-checkbox>
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+      <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
+      <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
+        Scales like Cantrip
       </mat-checkbox>
     </div>
   `,

--- a/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
@@ -17,14 +17,15 @@ import {EffectComponent} from '../shared/EffectComponent';
           <mat-option value="cha">Charisma</mat-option>
         </mat-select>
       </mat-form-field>
-      <mat-checkbox [(ngModel)]="custom" (change)="changed.emit(); onCustomChange()">
+      <mat-checkbox [(ngModel)]="custom" (change)="changed.emit(); onCustomChange()" *ngIf="spell != null">
         Has custom DC
       </mat-checkbox>
       <mat-form-field *ngIf="custom">
-        <input matInput placeholder="Custom DC" (change)="changed.emit()" [(ngModel)]="effect.dc">
+        <input matInput placeholder="DC" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.dc">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
+
     <mat-expansion-panel class="hoverable">
       <mat-expansion-panel-header>
         <mat-panel-title>
@@ -77,7 +78,7 @@ export class SaveEffectComponent extends EffectComponent<Save> implements OnInit
 
   onCustomChange() {
     if (!this.custom) {
-      this.effect.dc = '';
+      this.effect.dc = undefined;
     }
   }
 

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
@@ -42,18 +42,19 @@ import {EffectComponent} from '../shared/EffectComponent';
     </div>
 
     <div *ngIf="custom" fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-form-field>
-        <input matInput placeholder="DC" (change)="changed.emit()" [(ngModel)]="effect.dc">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="DC" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.dc">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
 
-      <mat-form-field>
-        <input matInput placeholder="Spell Attack Bonus" (change)="changed.emit()" [(ngModel)]="effect.attackBonus">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Spell Attack Bonus" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.attackBonus">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
 
-      <mat-form-field>
-        <input matInput placeholder="Spellcasting Modifier" (change)="changed.emit()" [(ngModel)]="effect.castingMod">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Spellcasting Modifier" class="text-monospace" (change)="changed.emit()"
+               [(ngModel)]="effect.castingMod">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
     </div>
@@ -79,9 +80,9 @@ export class SpellEffectComponent extends EffectComponent<CastSpell> implements 
 
   onCustomChange() {
     if (!this.custom) {
-      this.effect.dc = null;
-      this.effect.attackBonus = null;
-      this.effect.castingMod = null;
+      this.effect.dc = undefined;
+      this.effect.attackBonus = undefined;
+      this.effect.castingMod = undefined;
     }
   }
 

--- a/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
@@ -6,12 +6,14 @@ import {EffectComponent} from '../shared/EffectComponent';
   selector: 'avr-temphp-effect',
   template: `
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-form-field>
-        <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount">
+      <mat-form-field fxFlex>
+        <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
-      <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
-      <mat-checkbox *ngIf="spell != null" [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
+    </div>
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+      <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
+      <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip
       </mat-checkbox>
     </div>

--- a/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.ts
@@ -6,21 +6,22 @@ import {EffectComponent} from '../shared/EffectComponent';
   selector: 'avr-variable-effect',
   template: `
     <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
-      <mat-form-field>
-        <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name">
+      <mat-form-field fxFlex="1 3 auto">
+        <input matInput placeholder="Name" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.name" required>
       </mat-form-field>
 
-      <mat-form-field>
-        <input matInput placeholder="Value" (change)="changed.emit()" [(ngModel)]="effect.value">
+      <mat-form-field fxFlex="3 1 auto">
+        <input matInput placeholder="Value" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.value" required>
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
 
-      <mat-form-field>
-        <input matInput placeholder="On Error" (change)="changed.emit()" [(ngModel)]="effect.onError">
+      <mat-form-field fxFlex="2 1 auto">
+        <input matInput placeholder="On Error" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.onError">
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>
       </mat-form-field>
-
-      <avr-higher-level *ngIf="spell != null" [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
+    </div>
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" *ngIf="spell != null">
+      <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
     </div>
   `,
   styleUrls: ['../effect-editor.component.css']

--- a/src/app/shared/dialogs/json-import-dialog/json-import-dialog.component.css
+++ b/src/app/shared/dialogs/json-import-dialog/json-import-dialog.component.css
@@ -1,3 +1,12 @@
 .form-container > * {
   width: 100%;
 }
+
+::ng-deep .validation-error-header, 
+::ng-deep .validation-error-list {
+  margin: 0;
+}
+
+::ng-deep .validation-error-item {
+  margin: 12px 0 0 0 !important;
+}

--- a/src/app/shared/dialogs/json-import-dialog/json-import-dialog.component.html
+++ b/src/app/shared/dialogs/json-import-dialog/json-import-dialog.component.html
@@ -12,7 +12,7 @@
       <textarea matInput [placeholder]="jsonOrYaml" rows="10" [(ngModel)]="data"></textarea>
     </mat-form-field>
   </div>
-  <mat-error *ngIf="error"><span class="preserve-whitespace">{{error}}</span></mat-error>
+  <mat-error *ngIf="error" ><div [innerHTML]="error"></div></mat-error>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close>Cancel</button>

--- a/src/app/shared/validation-snackbar/validation-snackbar.component.css
+++ b/src/app/shared/validation-snackbar/validation-snackbar.component.css
@@ -1,0 +1,25 @@
+.validation-error {
+  display: flex;
+  flex-direction: column;
+}
+
+::ng-deep .validation-error-header{
+  margin: 0 0 0.5em 0;
+}
+
+::ng-deep .validation-error-list{
+  margin: 0 0 0.25em 0;
+}
+
+::ng-deep .validation-error-item{
+  margin: 0;
+}
+
+::ng-deep .mat-simple-snackbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  line-height: 20px;
+  opacity: 1;
+  gap: 1rem;
+}

--- a/src/app/shared/validation-snackbar/validation-snackbar.component.html
+++ b/src/app/shared/validation-snackbar/validation-snackbar.component.html
@@ -1,0 +1,9 @@
+<div class="mat-simple-snackbar">
+  <div [innerHTML]="data.html" class="validation-error"></div>
+  <div class="mat-simple-snackbar-action ng-star-inserted">
+    <button mat-raised-button (click)="snackBar.dismiss()" 
+            class="mat-focus-indicator mat-button mat-button-base">
+      Close
+    </button>
+  </div>
+</div>

--- a/src/app/shared/validation-snackbar/validation-snackbar.component.ts
+++ b/src/app/shared/validation-snackbar/validation-snackbar.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import { MatSnackBar, MAT_SNACK_BAR_DATA, MAT_SNACK_BAR_DEFAULT_OPTIONS } from "@angular/material/snack-bar";
+import { Inject } from '@angular/core';  
+
+
+@Component({
+  selector: 'validation-snackbar',
+  templateUrl: 'validation-snackbar.component.html',
+  styleUrls: ['./validation-snackbar.component.css']
+})
+
+export class ValidationSnackbar { 
+  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: any,
+              public snackBar: MatSnackBar) {
+  }
+}


### PR DESCRIPTION
### Summary
- Refactors all the homebrew services to use APIResponse (**depends on avrae-service PR**)
- Fixes an issue where view permission errors would not display when viewing private packs/tomes/collections
- Adds fields to support IEffect parent vars (avrae 2021w49)
- Misc style touchups to the Automation Editor
- Resolves avrae/avrae#1683
- Resolves avrae/avrae#1637

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
