### PR TITLE
feat(automation): add target sorting builder

### DIFF
--- a/src/app/schemas/homebrew/AutomationEffects.ts
+++ b/src/app/schemas/homebrew/AutomationEffects.ts
@@ -24,11 +24,13 @@ export class AutomationEffect {
 export class Target extends AutomationEffect {
   target: string | number;  // 'all' | 'each' | number | 'self'
   effects: AutomationEffect[];
+  sortBy?: string;  // 'hp_asc' | 'hp_desc'
 
-  constructor(target = 'all', effects = [], meta?) {
+  constructor(target = 'all', effects = [], sortBy?, meta?) {
     super('target', meta);
     this.target = target;
     this.effects = effects;
+    this.sortBy = sortBy;
   }
 }
 

--- a/src/app/shared/automation-editor/effect-editor/target-effect/target-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/target-effect/target-effect.component.ts
@@ -1,6 +1,10 @@
 import {Component, OnInit} from '@angular/core';
+import {MatSelectChange} from '@angular/material/select';
 import {Target} from '../../../../schemas/homebrew/AutomationEffects';
 import {EffectComponent} from '../shared/EffectComponent';
+
+type TargetType = 'all' | 'each' | 'self' | 'position';
+type TargetSortType = 'user' | 'hp_asc' | 'hp_desc';
 
 @Component({
   selector: 'avr-target-effect',
@@ -8,23 +12,38 @@ import {EffectComponent} from '../shared/EffectComponent';
     <div fxLayout="row" fxLayoutGap="6px">
       <mat-form-field>
         <mat-label>Target</mat-label>
-        <mat-select [(value)]="effect.target" (selectionChange)="changed.emit()">
+        <mat-select [(value)]="selectedTarget" (selectionChange)="onTargetSelectChange($event)">
           <mat-option value="all">All (usually saves)</mat-option>
           <mat-option value="each">Each (usually attacks)</mat-option>
           <mat-option value="self">Caster</mat-option>
-          <mat-option [value]="targetPosInput.value" (click)="effect.target=1">Position</mat-option>
+          <mat-option value="position">Position</mat-option>
         </mat-select>
       </mat-form-field>
-      <mat-form-field [ngClass]="!isNumber(effect.target) ? 'hidden' : ''">
-        <input matInput placeholder="Target Position" type="number" [value]="effect.target" #targetPosInput
-               (change)="onTargetPosChange(targetPosInput)" min="1">
+
+      <!-- target position -->
+      <mat-form-field *ngIf="isNumber(effect.target)">
+        <input matInput placeholder="Target Position" type="number" min="1"
+               [value]="effect.target.toString()" (change)="onTargetPosChange(targetPosInput)" #targetPosInput>
+      </mat-form-field>
+
+      <!-- target sorting -->
+      <mat-form-field *ngIf="effect.target !== 'self'"
+                      matTooltip="If not given, targets are processed in the order the -t arguments are given. Usually this is what you want.">
+        <mat-label>Sort Targets By</mat-label>
+        <mat-select [(value)]="selectedTargetSort" (selectionChange)="onTargetSortChange($event)">
+          <mat-option value="user">User Input</mat-option>
+          <mat-option value="hp_asc">HP Ascending</mat-option>
+          <mat-option value="hp_desc">HP Descending</mat-option>
+        </mat-select>
       </mat-form-field>
     </div>
+
     <avr-effect-editor [parent]="effect.effects"
                        [parentTypeStack]="newParentTypeStack"
                        [spell]="spell"
                        (changed)="changed.emit()">
     </avr-effect-editor>
+
     <avr-new-effect-card [metaParent]="effect.meta"
                          [parent]="effect.effects"
                          [parentTypeStack]="newParentTypeStack"
@@ -34,20 +53,48 @@ import {EffectComponent} from '../shared/EffectComponent';
   styleUrls: ['../effect-editor.component.css']
 })
 export class TargetEffectComponent extends EffectComponent<Target> implements OnInit {
+  selectedTarget: TargetType = 'all';
+  selectedTargetSort: TargetSortType = 'user';
+
   constructor() {
     super();
   }
 
   ngOnInit() {
+    this.selectedTarget = typeof this.effect.target === 'number' ? 'position' : this.effect.target as TargetType;
+    this.selectedTargetSort = (this.effect.sortBy ?? 'user') as TargetSortType;
   }
 
   isNumber(val) {
     return typeof val === 'number';
   }
 
-  onTargetPosChange(targetPosInput) {
+  onTargetSelectChange(changeEvent: MatSelectChange) {
+    if (changeEvent.value === 'position') {
+      this.effect.target = 1;
+    } else {
+      this.effect.target = changeEvent.value;
+    }
+
+    if (changeEvent.value === 'self') {
+      this.selectedTargetSort = 'user';
+      this.effect.sortBy = undefined;
+    }
+
     this.changed.emit();
-    this.effect.target = +targetPosInput.value;
   }
 
+  onTargetPosChange(targetPosInput) {
+    this.effect.target = +targetPosInput.value;
+    this.changed.emit();
+  }
+
+  onTargetSortChange(changeEvent: MatSelectChange) {
+    if (changeEvent.value === 'user') {
+      this.effect.sortBy = undefined;
+    } else {
+      this.effect.sortBy = changeEvent.value;
+    }
+    this.changed.emit();
+  }
 }


### PR DESCRIPTION
Adds the automation builder for `Target.sortBy` (added in https://github.com/avrae/avrae/pull/1707).

Depends on avrae/avrae-service#44.

cc @lathaon

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
