### PR TITLE
Mobile Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.sublime-workspace
 
 # IDE - VSCode
+/.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.html
+++ b/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.html
@@ -9,7 +9,7 @@
     </p>
   </div>
 
-  <div fxLayout="row">
+  <div fxLayout="row" class="auto-row">
     <mat-form-field>
       <mat-label>Select an attack</mat-label>
       <mat-select [(value)]="selectedAttack">
@@ -20,20 +20,22 @@
       </mat-select>
     </mat-form-field>
 
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Import YAML" (click)="beginYAMLImport()">
-        <mat-icon aria-label="Import from YAML">vertical_align_bottom</mat-icon>
-      </button>
-    </span>
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Copy SRD Monster Action" (click)="newFromSRD()">
-        <mat-icon aria-label="Copy SRD Monster Action">scanner</mat-icon>
-      </button>
-    </span>
-    <span fxFlex>
-      <button mat-icon-button matTooltip="Export All to YAML" (click)="beginYAMLExport(allAttacks)">
-        <mat-icon aria-label="Export All to YAML">vertical_align_top</mat-icon>
-      </button>
+    <span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Import YAML" (click)="beginYAMLImport()">
+          <mat-icon aria-label="Import from YAML">vertical_align_bottom</mat-icon>
+        </button>
+      </span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Copy SRD Monster Action" (click)="newFromSRD()">
+          <mat-icon aria-label="Copy SRD Monster Action">scanner</mat-icon>
+        </button>
+      </span>
+      <span fxFlex>
+        <button mat-icon-button matTooltip="Export All to YAML" (click)="beginYAMLExport(allAttacks)">
+          <mat-icon aria-label="Export All to YAML">vertical_align_top</mat-icon>
+        </button>
+      </span>
     </span>
     <span fxFlex="grow"></span>
   </div>
@@ -44,22 +46,21 @@
 
   <div *ngIf="selectedAttack">
     <!-- name, delete, export -->
-    <div fxLayout="row" fxLayoutGap="4px">
+    <div fxLayout="row" fxLayoutGap="4px" class="auto-row">
       <mat-form-field fxFlex="grow">
         <input matInput placeholder="Attack Name" [(ngModel)]="selectedAttack.name">
       </mat-form-field>
-
-      <span fxFlex="grow"></span>
-
-      <span fxFlex>
-        <button mat-icon-button color="warn" (click)="deleteAttack(selectedAttack)">
-          <mat-icon>delete</mat-icon>
-        </button>
-      </span>
-      <span fxFlex>
-        <button mat-icon-button matTooltip="Export to YAML" (click)="beginYAMLExport(selectedAttack)">
-          <mat-icon aria-label="Export to YAML">vertical_align_top</mat-icon>
-        </button>
+      <span>
+        <span fxFlex>
+          <button mat-icon-button color="warn" (click)="deleteAttack(selectedAttack)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </span>
+        <span fxFlex>
+          <button mat-icon-button matTooltip="Export to YAML" (click)="beginYAMLExport(selectedAttack)">
+            <mat-icon aria-label="Export to YAML">vertical_align_top</mat-icon>
+          </button>
+        </span>
       </span>
     </div>
 
@@ -72,7 +73,7 @@
 
     <div class="advanced-options" *ngIf="showAdvancedOptions">
       <!-- display options -->
-      <mat-divider></mat-divider>
+      <mat-divider class="beefy-divider"></mat-divider>
       <h3>
         Display Options
       </h3>
@@ -99,11 +100,11 @@
       </div>
 
       <!-- crit options -->
-      <mat-divider></mat-divider>
+      <mat-divider class="beefy-divider"></mat-divider>
       <h3>
         Critical Hit Options
       </h3>
-      <div class="crit-options-container">
+      <div class="crit-options-container auto-row">
         <mat-form-field>
           <input matInput placeholder="Criton" [(ngModel)]="selectedAttack.criton" type="number" min="1" max="20"
                  matTooltip="The natural roll this attack will crit on.">
@@ -117,7 +118,7 @@
     </div>
 
     <!-- automation editor -->
-    <mat-divider></mat-divider>
+    <mat-divider class="beefy-divider"></mat-divider>
     <h3>
       Automation
     </h3>
@@ -139,9 +140,11 @@
 
 <!-- Buttons -->
 <mat-dialog-actions>
-  <button mat-flat-button mat-dialog-close>Cancel</button>
-  <button mat-flat-button (click)="save()" [disabled]="saveButtonDisabled"
-          color="primary">{{saveButtonValue}}</button>
-  <button mat-flat-button (click)="saveAndExit()" [disabled]="saveButtonDisabled"
-          color="primary">{{saveAndExitButtonValue}}</button>
+  <button mat-flat-button mat-dialog-close color="warn">Cancel</button>
+  <span>
+    <button mat-flat-button (click)="save()" [disabled]="saveButtonDisabled"
+            color="primary">{{saveButtonValue}}</button>
+    <button mat-flat-button (click)="saveAndExit()" [disabled]="saveButtonDisabled"
+            color="primary">{{saveAndExitButtonValue}}</button>
+  </span>
 </mat-dialog-actions>

--- a/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.scss
+++ b/src/app/dashboard/characters/attack-editor-dialog/attack-editor-dialog.component.scss
@@ -21,7 +21,47 @@
 }
 
 .crit-options-container {
-  display: grid;
+  display: flex;
   grid-template-columns: auto 1fr;
   grid-column-gap: 8px;
+}
+
+
+mat-dialog-actions {
+  gap: 8px;
+}
+
+@media (max-width: 600px) {
+
+  mat-dialog-actions {
+    justify-content: center;
+    flex-direction: column-reverse;
+  }
+
+}
+@media (max-width: 960px) {
+  .auto-row {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .auto-row span, .auto-row mat-form-field {
+    width: 100%;
+    justify-content: space-around;
+  }
+
+  .auto-row span span {
+    display: flex;
+    justify-content: center;
+  }
+
+  mat-dialog-actions span {
+    gap: 8px;
+    display: flex;
+    justify-content: center;
+  }
+
+  mat-dialog-actions span button {
+    margin: 0;
+  }
 }

--- a/src/app/dashboard/characters/characters.component.css
+++ b/src/app/dashboard/characters/characters.component.css
@@ -85,7 +85,7 @@
 }
 
 .character-tile:hover .character-image {
-  webkit-filter: blur(3px) brightness(0.7); /* Chrome, Safari, Opera */
+  -webkit-filter: blur(3px) brightness(0.7); /* Chrome, Safari, Opera */
   filter: blur(3px) brightness(0.7);
   transform: scale(1.05);
 }
@@ -108,4 +108,45 @@
 
 .character-meta:hover {
   opacity: 1;
+}
+
+
+@media (max-width: 960px) {
+  ::ng-deep .automation-overlay {
+    max-width: 95vw !important;
+    width: 95% !important;
+  }
+
+  .character-meta {
+    opacity: 1;
+  }
+
+  .character-tile .character-image {
+    -webkit-filter: blur(3px) brightness(0.6); /* Chrome, Safari, Opera */
+    filter: blur(3px) brightness(0.6);
+    transform: scale(1.05);
+  }
+
+  .character-meta .mat-typography p {
+    -webkit-line-clamp: 10;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  avr-attack-editor-dialog mat-dialog-content div {
+    flex-wrap: wrap;
+  }
+
+  .mat-typography.ignore-theme.character-actions {
+    display: flex;
+    justify-content: space-evenly;
+  }
+}
+
+@media (max-width: 600px) {
+  .avatarImg {
+    width: 40%;
+  }
 }

--- a/src/app/dashboard/characters/characters.component.html
+++ b/src/app/dashboard/characters/characters.component.html
@@ -1,10 +1,10 @@
 <div class="characterList">
   <mat-card class="user-card" *ngIf="(userInfo | async)">
-    <mat-grid-list cols="4" rowHeight="1:1">
-      <mat-grid-tile>
+    <mat-grid-list cols="4" rowHeight="{{ !mobile ? '1:1' : '1:2' }}">
+      <mat-grid-tile colspan="{{ !mobile ? 1 : 4 }}" >
         <img alt="avatar" [src]="(userInfo | async)?.avatarUrl" class="avatarImg mat-elevation-z1">
       </mat-grid-tile>
-      <mat-grid-tile colspan="3">
+      <mat-grid-tile colspan="{{ !mobile ? 3 : 4 }}" class="user-stats">
         <div>
           <h1 class="mat-display-2 smallmargin">
             {{(userInfo | async)?.username}}<span class="mat-small">#{{(userInfo | async)?.discriminator}}</span>
@@ -34,7 +34,9 @@
           <h3>
             {{character.name}}
           </h3>
-          {{getDescription(character)}}
+          <p>
+            {{getDescription(character)}}
+          </p>
         </div>
         <div class="mat-typography ignore-theme character-actions">
           <a mat-icon-button matTooltip="View Sheet"

--- a/src/app/dashboard/characters/characters.component.ts
+++ b/src/app/dashboard/characters/characters.component.ts
@@ -6,13 +6,15 @@ import {UserInfo, UserStats} from '../../schemas/UserInfo';
 import {getUser} from '../APIHelper';
 import {DashboardService} from '../dashboard.service';
 import {AttackEditorDialog} from './attack-editor-dialog/attack-editor-dialog.component';
+import {BreakpointObserver} from '@angular/cdk/layout';
+import {BreakpointBaseComponent} from '../../shared/breakpoints';
 
 @Component({
   selector: 'avr-characters',
   templateUrl: './characters.component.html',
   styleUrls: ['./characters.component.css']
 })
-export class CharactersComponent implements OnInit {
+export class CharactersComponent extends BreakpointBaseComponent implements OnInit {
 
   userInfo: Observable<UserInfo>;
   userStats: Observable<UserStats>;
@@ -21,8 +23,11 @@ export class CharactersComponent implements OnInit {
 
   MIN_CHARACTER_AUTOMATION_VERSION = 17;
 
-  constructor(private dashboardService: DashboardService, private dialog: MatDialog) {
-  }
+  constructor(private dashboardService: DashboardService,
+    private dialog: MatDialog,
+    private bp: BreakpointObserver) {
+      super(bp);
+    }
 
   ngOnInit() {
     this.getUserInfo();
@@ -75,7 +80,8 @@ export class CharactersComponent implements OnInit {
 
     this.dialog.open(AttackEditorDialog, {
       width: '75%', disableClose: true,
-      data: character
+      data: character,
+      panelClass: 'automation-overlay'
     })
       .afterClosed().subscribe(result => {
       console.log(result);

--- a/src/app/dashboard/customization/alias-list/alias-list.component.css
+++ b/src/app/dashboard/customization/alias-list/alias-list.component.css
@@ -24,7 +24,7 @@ td {
 }
 
 tr:nth-child(even) {
-  background: rgba(204, 204, 204, .15);
+  background: #545454;
 }
 
 
@@ -38,5 +38,5 @@ td.mat-cell, td.mat-footer-ce   ll, th.mat-header-cell {
 
 
 th {
-  min-width: 120px;
+  min-width: 100px;
 }

--- a/src/app/dashboard/customization/alias-list/alias-list.component.html
+++ b/src/app/dashboard/customization/alias-list/alias-list.component.html
@@ -1,5 +1,5 @@
 <table mat-table [dataSource]="data" matSort class="list-table">
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
     <td mat-cell *matCellDef="let alias">{{alias.name}}</td>
     <td mat-footer-cell *matFooterCellDef>Create New</td>
@@ -13,7 +13,7 @@
     <td mat-footer-cell *matFooterCellDef></td>
   </ng-container>
 
-  <ng-container matColumnDef="buttons">
+  <ng-container matColumnDef="buttons" stickyEnd>
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let alias">
       <button mat-icon-button (click)="beginEdit(alias)">

--- a/src/app/dashboard/customization/snippet-list/snippet-list.component.css
+++ b/src/app/dashboard/customization/snippet-list/snippet-list.component.css
@@ -24,7 +24,7 @@ td {
 }
 
 tr:nth-child(even) {
-  background: rgba(204, 204, 204, .15);
+  background: #545454;
 }
 
 
@@ -38,5 +38,5 @@ td.mat-cell, td.mat-footer-ce   ll, th.mat-header-cell {
 
 
 th {
-  min-width: 120px;
+  min-width: 100px;
 }

--- a/src/app/dashboard/customization/snippet-list/snippet-list.component.html
+++ b/src/app/dashboard/customization/snippet-list/snippet-list.component.html
@@ -1,5 +1,5 @@
 <table mat-table [dataSource]="data" matSort class="list-table">
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
     <td mat-cell *matCellDef="let snippet">{{snippet.name}}</td>
     <td mat-footer-cell *matFooterCellDef>Create New</td>
@@ -13,7 +13,7 @@
     <td mat-footer-cell *matFooterCellDef></td>
   </ng-container>
 
-  <ng-container matColumnDef="buttons">
+  <ng-container matColumnDef="buttons" stickyEnd>
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let snippet">
       <button mat-icon-button (click)="beginEdit(snippet)">

--- a/src/app/dashboard/customization/uvar-list/uvar-list.component.css
+++ b/src/app/dashboard/customization/uvar-list/uvar-list.component.css
@@ -24,7 +24,7 @@ td {
 }
 
 tr:nth-child(even) {
-  background: rgba(204, 204, 204, .15);
+  background: #545454;
 }
 
 
@@ -38,5 +38,5 @@ td.mat-cell, td.mat-footer-ce   ll, th.mat-header-cell {
 
 
 th {
-  min-width: 120px;
+  min-width: 100px;
 }

--- a/src/app/dashboard/customization/uvar-list/uvar-list.component.html
+++ b/src/app/dashboard/customization/uvar-list/uvar-list.component.html
@@ -1,5 +1,5 @@
 <table mat-table [dataSource]="data" matSort class="list-table">
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
     <td mat-cell *matCellDef="let uvar">{{uvar.name}}</td>
     <td mat-footer-cell *matFooterCellDef>Create New</td>
@@ -13,7 +13,7 @@
     <td mat-footer-cell *matFooterCellDef></td>
   </ng-container>
 
-  <ng-container matColumnDef="buttons">
+  <ng-container matColumnDef="buttons" stickyEnd>
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let uvar">
       <button mat-icon-button (click)="beginEdit(uvar)">

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -17,7 +17,7 @@
     class="sidenav mat-elevation-z3"
     fixedTopGap="56px">
     <mat-nav-list>
-      <a mat-list-item [routerLink]="['characters']">Characters</a>
+      <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" [routerLink]="['characters']">Characters</a>
 
       <mat-expansion-panel expanded class="mat-elevation-z0">
         <mat-expansion-panel-header>
@@ -26,9 +26,9 @@
           </mat-panel-title>
         </mat-expansion-panel-header>
         <div class="nav-panel-body">
-          <a mat-list-item routerLink="/dashboard/workshop">Explore</a>
-          <a mat-list-item routerLink="/dashboard/workshop/my-subscriptions">My Subscriptions</a>
-          <a mat-list-item routerLink="/dashboard/workshop/my-work">My Work</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/workshop">Explore</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/workshop/my-subscriptions">My Subscriptions</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/workshop/my-work">My Work</a>
         </div>
       </mat-expansion-panel>
 
@@ -39,8 +39,8 @@
           </mat-panel-title>
         </mat-expansion-panel-header>
         <div class="nav-panel-body">
-          <a mat-list-item [routerLink]="['aliases']">My Customizations</a>
-          <a mat-list-item [routerLink]="['gvars']">Global Variables</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" [routerLink]="['aliases']">My Customizations</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" [routerLink]="['gvars']">Global Variables</a>
         </div>
       </mat-expansion-panel>
 
@@ -51,9 +51,9 @@
           </mat-panel-title>
         </mat-expansion-panel-header>
         <div class="nav-panel-body">
-          <a mat-list-item routerLink="/dashboard/homebrew/items">Items</a>
-          <a mat-list-item routerLink="/dashboard/homebrew/spells">Spells</a>
-          <a mat-list-item href="https://critterdb.com/#/index" target="_blank" rel="noopener noreferrer">Creatures
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/homebrew/items">Items</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/homebrew/spells">Spells</a>
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" href="https://critterdb.com/#/index" target="_blank" rel="noopener noreferrer">Creatures
             <mat-icon class="icon-in-panel">launch</mat-icon>
           </a>
         </div>

--- a/src/app/dashboard/gvars/gvar-list/gvar-list.component.css
+++ b/src/app/dashboard/gvars/gvar-list/gvar-list.component.css
@@ -24,7 +24,7 @@ td {
 }
 
 tr:nth-child(even) {
-  background: rgba(204, 204, 204, .15);
+  background: #545454;
 }
 
 
@@ -38,5 +38,5 @@ td.mat-cell, td.mat-footer-cell, th.mat-header-cell {
 
 
 th {
-  min-width: 120px;
+  min-width: 100px;
 }

--- a/src/app/dashboard/gvars/gvar-list/gvar-list.component.html
+++ b/src/app/dashboard/gvars/gvar-list/gvar-list.component.html
@@ -1,5 +1,5 @@
 <table mat-table [dataSource]="sortedGvars(data)" class="list-table">
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef>ID</th>
     <td mat-cell *matCellDef="let gvar">{{gvar.key}}</td>
     <td mat-footer-cell *matFooterCellDef>{{owned ? "Create New" : ""}}</td>
@@ -13,7 +13,7 @@
     <td mat-footer-cell *matFooterCellDef></td>
   </ng-container>
 
-  <ng-container matColumnDef="buttons">
+  <ng-container matColumnDef="buttons" stickyEnd>
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let gvar">
       <button mat-icon-button (click)="beginEdit(gvar)">

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.html
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.html
@@ -60,7 +60,7 @@
       </mat-card>
     </div>
 
-    <div class="item-preview mat-typography mat-elevation-z3" fxFlex="grow">
+    <div class="item-preview mat-typography mat-elevation-z3" fxFlex="grow" fxHide fxShow.gt-xs="true">
       <avr-discord-embed *ngIf="selectedItem" [author]="{name: user.username, icon_url: user.avatarUrl}"
                          [title]="selectedItem.name" [description]="selectedItem.meta"
                          [fields]="[{name: 'Description', value: selectedItem.desc}]"

--- a/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.scss
+++ b/src/app/dashboard/homebrew/items/pack-detail/pack-detail.component.scss
@@ -28,6 +28,7 @@ $viewport-height: calc(100vh - #{$navbar-height + $footer-height + $pack-toolbar
 .new-item-card {
   height: 48px;
   padding: 0 24px;
+  margin-top: 8px;
 }
 
 .no-text-cursor {

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-detail/spell-detail.component.html
@@ -21,7 +21,7 @@
       </div>
 
       <!-- LEVEL, SCHOOL, RITUAL -->
-      <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
+      <div fxLayout="row wrap" fxLayoutGap="6px" fxLayoutAlign="center center">
         <mat-form-field fxFlex>
           <mat-label>Level</mat-label>
           <mat-select [(value)]="spell.level" (selectionChange)="emitChange()">
@@ -59,22 +59,22 @@
           </button>
         </mat-form-field>
 
-        <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.ritual" (change)="emitChange()">Ritual</mat-checkbox>
+        <mat-checkbox style="padding-right: 4px;" fxFlex="nogrow" [(ngModel)]="spell.ritual" (change)="emitChange()">Ritual</mat-checkbox>
       </div>
 
       <!-- TIME AND RANGE -->
-      <div fxLayout="row" fxLayoutGap="6px">
-        <mat-form-field fxFlex>
+      <div fxLayout="row wrap" style="gap: 6px;">
+        <mat-form-field fxFlex style="max-width: calc(50%-3px)">
           <input matInput placeholder="Casting Time" (change)="emitChange()" [(ngModel)]="spell.casttime">
         </mat-form-field>
 
-        <mat-form-field fxFlex>
+        <mat-form-field fxFlex style="max-width: calc(50%-3px)">
           <input matInput placeholder="Range" (change)="emitChange()" [(ngModel)]="spell.range">
         </mat-form-field>
       </div>
 
       <!-- COMPONENTS -->
-      <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
+      <div fxLayout="row wrap" fxLayoutGap="6px" fxLayoutAlign="center center">
         <mat-checkbox fxFlex="nogrow" [(ngModel)]="spell.components.verbal" (change)="emitChange()">
           Verbal
         </mat-checkbox>
@@ -87,7 +87,7 @@
       </div>
 
       <!-- DURATION AND CONC -->
-      <div fxLayout="row" fxLayoutGap="6px" fxLayoutAlign="center center">
+      <div fxLayout="row wrap" fxLayoutGap="6px" fxLayoutAlign="center center">
         <mat-form-field fxFlex>
           <input matInput placeholder="Duration" (change)="emitChange()" [(ngModel)]="spell.duration">
         </mat-form-field>
@@ -110,7 +110,7 @@
       </mat-form-field>
 
       <!-- CLASSES AND SUBCLASSES -->
-      <div fxLayout="row" fxLayoutGap="6px">
+      <div fxLayout="row wrap" fxLayoutGap="6px">
         <mat-form-field fxFlex matTooltip="Separate classes with commas.">
           <input matInput placeholder="Classes" (change)="emitChange()" [(ngModel)]="spell.classes">
         </mat-form-field>

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.html
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.html
@@ -36,7 +36,7 @@
     </mat-card>
   </div>
 
-  <div class="spell-preview mat-typography mat-elevation-z3" fxFlex="grow">
+  <div class="spell-preview mat-typography mat-elevation-z3" fxFlex="grow" fxHide fxShow.gt-xs="true">
     <avr-spell-embed [name]="selectedSpell?.name" [image]="selectedSpell?.image" [level]="selectedSpell?.level"
                      [school]="selectedSpell?.school" [classes]="selectedSpell?.classes"
                      [subclasses]="selectedSpell?.subclasses" [verbal]="selectedSpell?.components.verbal"

--- a/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.scss
+++ b/src/app/dashboard/homebrew/spells/tome-detail/spell-list/spell-list.component.scss
@@ -21,6 +21,7 @@ $viewport-height: calc(100vh - #{$navbar-height + $footer-height + $tome-toolbar
 .new-spell-card {
   height: $new-spell-card-height;
   padding: 0 24px;
+  margin-top: 8px;
 }
 
 .toolbar-spacer {

--- a/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.html
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.html
@@ -34,8 +34,8 @@
       Need some references? You can <a href="https://avrae.readthedocs.io/en/stable/aliasing/api.html" target="_blank">
       find the Draconic documentation here</a>.
     </p>
-    <!-- <button (click)="toggleWordWrap()">{{ this.wordWrap === 'on' ? 'Word Wrap Enabled' : 'Word Wrap Disabled' }}</button> -->
     <mat-slide-toggle (change)="toggleWordWrap()">Word Wrap</mat-slide-toggle>
+    <mat-slide-toggle *ngIf="mobile" (change)="toggleCodeVersions()">Code Versions</mat-slide-toggle>
     <div class="code-versions-container ignore-theme">
       <!-- code editor: display selected, edit new version, or placeholder if nothing selected -->
       <div class="code-editor">
@@ -53,7 +53,7 @@
         </p>
       </div>
       <!-- code version viewer -->
-      <div class="code-versions-list">
+      <div class="code-versions-list" [ngClass]="{'mobile-code-version' : mobileCodeVersion}">
         <mat-action-list>
           <button mat-list-item (click)="onStartCreatingCodeVersion()" [class.active]="creatingNewCodeVersion"
                   class="ignore-theme">

--- a/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.scss
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.scss
@@ -49,3 +49,19 @@ mat-form-field {
 .active {
   background: rgba(white, 0.05);
 }
+
+@media (max-width: 600px) {
+  .code-versions-list {
+    display: none;
+    background: $gray-dark1;
+    right: 0;
+    position: absolute;
+    z-index: 20;
+  }
+  .code-versions-container {
+    position: relative;
+  }
+  .mobile-code-version {
+    display: block;
+  }
+}

--- a/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.ts
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.ts
@@ -19,6 +19,8 @@ import {GamedataService} from '../../../../shared/gamedata.service';
 import {ApiResponse} from '../../../APIHelper';
 import {ConfirmDeleteDialog} from '../../../confirm-delete-dialog/confirm-delete-dialog.component';
 import {WorkshopService} from '../../workshop.service';
+import {BreakpointObserver} from '@angular/cdk/layout';
+import {BreakpointBaseComponent} from '../../../../shared/breakpoints';
 
 interface CollectableEditDialogComponentData {
   collection: WorkshopCollectionFull;
@@ -32,16 +34,21 @@ interface CollectableEditDialogComponentData {
   templateUrl: './collectable-edit-dialog.component.html',
   styleUrls: ['./collectable-edit-dialog.component.scss', '../../dialog-common.scss', '../../common.scss']
 })
-export class CollectableEditDialogComponent implements OnInit {
+export class CollectableEditDialogComponent extends BreakpointBaseComponent implements OnInit {
   PublicationState = PublicationState;
   wordWrap = 'off';
+  mobileCodeVersion = false;
   editorOptions = {theme: 'draconicTheme', language: 'draconic', scrollBeyondLastLine: false, wordWrap: this.wordWrap};
-  readonlyEditorOptions = {...this.editorOptions, readOnly: true};  
+  readonlyEditorOptions = {...this.editorOptions, readOnly: true};
 
   toggleWordWrap() {
     this.wordWrap = this.wordWrap === 'on' ? 'off' : 'on'
     this.editorOptions = Object.assign({}, this.editorOptions, { wordWrap: this.wordWrap });
     this.readonlyEditorOptions = Object.assign({}, this.readonlyEditorOptions, { wordWrap: this.wordWrap });
+  }
+
+  toggleCodeVersions() {
+    this.mobileCodeVersion = !this.mobileCodeVersion
   }
 
   // data
@@ -70,7 +77,9 @@ export class CollectableEditDialogComponent implements OnInit {
   constructor(@Inject(MAT_DIALOG_DATA) public data: CollectableEditDialogComponentData,
               private dialogRef: MatDialogRef<CollectableEditDialogComponent>,
               private workshopService: WorkshopService, private gamedataService: GamedataService,
-              private dialog: MatDialog, private snackBar: MatSnackBar) {
+              private dialog: MatDialog, private snackBar: MatSnackBar,
+              private bp: BreakpointObserver) {
+    super(bp);
     this.collection = data.collection;
     this.alias = data.alias;
     this.parent = data.parent;

--- a/src/app/dashboard/workshop/collection-edit/collectable-edit/collectable-edit.component.ts
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit/collectable-edit.component.ts
@@ -31,6 +31,7 @@ export class CollectableEditComponent extends CollectableDisplayComponent implem
       {
         disableClose: true,
         minWidth: '70%',
+        panelClass: 'collectable-overlay',
         data: {collection: this.collection, alias: this.alias, snippet: this.snippet, parent: this.parentComponent?.alias}
       }
     );

--- a/src/app/dashboard/workshop/collection-edit/collection-edit.component.scss
+++ b/src/app/dashboard/workshop/collection-edit/collection-edit.component.scss
@@ -18,3 +18,10 @@
 .clickable {
   cursor: pointer;
 }
+
+@media (max-width: 960px) {
+  ::ng-deep .collectable-overlay {
+    max-width: 95vw !important;
+    width: 95% !important;
+  }
+}

--- a/src/app/dashboard/workshop/collection/collection.component.html
+++ b/src/app/dashboard/workshop/collection/collection.component.html
@@ -1,31 +1,34 @@
 <mat-toolbar color="primary">
-  <button mat-icon-button aria-label="Back" (click)="goBack()">
-    <mat-icon>arrow_back</mat-icon>
-  </button>
+  <div class="toolbar-title">
+    <button mat-icon-button aria-label="Back" (click)="goBack()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
 
-  <span>{{collection?.name || 'Loading...'}}</span>
-  <span class="toolbar-spacer"></span>
+    <span class="collection-name">{{collection?.name || 'Loading...'}}</span>
+    <span class="toolbar-spacer"></span>
 
-  <!-- edit, edit bindings -->
-  <a mat-icon-button aria-label="Edit Collection Button" matTooltip="Edit Collection"
-          *ngIf="canEdit()" [routerLink]="'./edit'" [skipLocationChange]="true">
-    <mat-icon>edit</mat-icon>
-  </a>
+    <!-- edit, edit bindings -->
+    <a mat-icon-button aria-label="Edit Collection Button" matTooltip="Edit Collection"
+            *ngIf="canEdit()" [routerLink]="'./edit'" [skipLocationChange]="true">
+      <mat-icon>edit</mat-icon>
+    </a>
 
-  <button mat-icon-button aria-label="Edit Bindings Button" matTooltip="Edit Bindings"
-          *ngIf="bindings" (click)="onEditBindings()">
-    <mat-icon>handyman</mat-icon>
-  </button>
+    <button mat-icon-button aria-label="Edit Bindings Button" matTooltip="Edit Bindings"
+            *ngIf="bindings" (click)="onEditBindings()">
+      <mat-icon>handyman</mat-icon>
+    </button>
+  </div>
+  <div class="toolbar-select">
+    <!-- loading, guild select -->
+    <mat-spinner *ngIf="loading" color="accent" diameter="24" class="toolbar-spinner"></mat-spinner>
 
-  <!-- loading, guild select -->
-  <mat-spinner *ngIf="loading" color="accent" diameter="24" class="toolbar-spinner"></mat-spinner>
-
-  <div class="toolbar-search-form">
-    <!-- guild context -->
-    <avr-guild-select-field class="toolbar-search-form-guild-context"
-                            label="View As"
-                            (guildChange)="onGuildContextChange($event)">
-    </avr-guild-select-field>
+    <div class="toolbar-search-form">
+      <!-- guild context -->
+      <avr-guild-select-field class="toolbar-search-form-guild-context"
+                              label="View As"
+                              (guildChange)="onGuildContextChange($event)">
+      </avr-guild-select-field>
+    </div>
   </div>
 
 </mat-toolbar>

--- a/src/app/dashboard/workshop/collection/collection.component.scss
+++ b/src/app/dashboard/workshop/collection/collection.component.scss
@@ -13,9 +13,9 @@
 }
 
 .metadata-grid {
-  display: grid;
+  display: flex;
   grid-template-columns: minmax(275px, 1fr) 275px;
-  grid-gap: 1rem;
+  gap: 1rem;
 
   .metadata {
     background: $gray-dark1;
@@ -52,11 +52,7 @@
   }
 }
 
-.desc-tags {
-  margin-top: 8px;
-}
-
-.desc-text {
+.desc-tags, .desc-text {
   margin-top: 8px;
 }
 
@@ -70,5 +66,63 @@
     color: $blurple;
     margin-bottom: 8px;
     font-weight: bold;
+  }
+}
+
+.collection-name {
+  max-width: 80vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+mat-toolbar {
+  justify-content: space-between;
+}
+
+
+@media (max-width: 960px) {
+  .metadata-container {
+    width: 65%
+  }
+
+  .desc-subscribe-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .desc-subscribe-buttons {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 600px) {
+  mat-toolbar {
+    display: flex;
+    height: 120px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  mat-toolbar .toolbar-title {
+    max-width: 100%;
+    display: flex;
+  }
+
+  .toolbar-select {
+    align-content: center;
+  }
+
+  .metadata-grid {
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 10px;
+  }
+
+
+  .metadata-container {
+    width: 100%
   }
 }

--- a/src/app/homebrew-sharing/pack-share/pack-share.component.html
+++ b/src/app/homebrew-sharing/pack-share/pack-share.component.html
@@ -35,7 +35,7 @@
       </mat-card>
     </div>
 
-    <div class="item-preview mat-typography mat-elevation-z3" fxFlex="grow">
+    <div class="item-preview mat-typography mat-elevation-z3" fxFlex="grow" fxHide fxShow.gt-xs="true">
       <avr-discord-embed *ngIf="selectedItem"
                          [title]="selectedItem.name" [description]="selectedItem.meta"
                          [fields]="[{name: 'Description', value: selectedItem.desc}]"

--- a/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.ts
@@ -6,7 +6,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-attack-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
       <mat-checkbox [(ngModel)]="custom" (change)="changed.emit(); onCustomChange()" *ngIf="spell != null">
         Has custom attack bonus
       </mat-checkbox>

--- a/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.ts
@@ -5,7 +5,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-condition-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field>
         <input matInput placeholder="Condition" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.condition" required>
         <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate</mat-icon>

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.ts
@@ -9,7 +9,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-counter-effect',
   template: `
-    <div>
+    <div class="auto-row">
       <span>Use {{counterType === 'ability' ? 'an' : 'a'}} </span>
 
       <mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/damage-effect/damage-effect.component.ts
@@ -5,17 +5,19 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-damage-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field fxFlex>
         <input matInput placeholder="Damage" (change)="changed.emit()" [(ngModel)]="effect.damage" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
-      <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
-        Allow Overheal
-      </mat-checkbox>
+      <span>
+        <mat-checkbox [(ngModel)]="effect.overheal" (change)="changed.emit()">
+          Allow Overheal
+        </mat-checkbox>
+      </span>
     </div>
 
-    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+    <div fxLayout="column" fxFill fxLayout.gt-xs="row" fxLayoutGap="8px" fxLayoutAlign="space-evenly center" fxLayoutAlign.gt-xs="left center" *ngIf="spell != null">
       <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
@@ -13,3 +13,25 @@
 ::ng-deep .adv-tooltip {
   white-space:  pre-line !important;
 }
+
+@media (max-width: 700px) {
+  .auto-row {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .auto-row span, .auto-row mat-form-field {
+    width: 100%;
+    justify-content: space-around;
+  }
+
+  .auto-row span, .auto-row span span {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  ::ng-deep .mat-expansion-panel-body {
+    padding: 0 8px 24px 16px;
+  }
+}

--- a/src/app/shared/automation-editor/effect-editor/higher-level/higher-level.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/higher-level/higher-level.component.ts
@@ -7,7 +7,7 @@ const range = (start, end) => Array.from({length: (end - start)}, (v, k) => k + 
 @Component({
   selector: 'avr-higher-level',
   template: `
-    <div *ngIf="parent.higher != undefined">
+    <div *ngIf="parent.higher != undefined" style="min-width: 300px;">
       <mat-expansion-panel class="higher-level-panel">
         <mat-expansion-panel-header>
           <mat-panel-title>

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.ts
@@ -5,7 +5,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-ieffect-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px">
+    <div fxLayout="row" fxLayoutGap="4px" class="auto-row">
       <mat-form-field fxFlex="1 2 auto">
         <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name" required>
       </mat-form-field>
@@ -20,18 +20,26 @@ import {EffectComponent} from '../shared/EffectComponent';
       </mat-form-field>
     </div>
 
-    <div fxLayout="row" fxLayoutGap="8px">
-      <mat-checkbox [(ngModel)]="effect.end" (change)="changed.emit();"
-                    matTooltip="Whether the effect duration ticks down at the end of the turn rather than the start.">
-        Ticks on end of turn?
-      </mat-checkbox>
-      <mat-checkbox [(ngModel)]="effect.conc" (change)="changed.emit();">
-        Requires concentration?
-      </mat-checkbox>
-      <mat-checkbox [(ngModel)]="effect.stacking" (change)="changed.emit();"
-                    matTooltip="If another effect with the same name exists, add this effect as a child instead of overwriting it.">
-        Stacking?
-      </mat-checkbox>
+    <div style="color: red; font-weight: bold; margin-bottom: 10px; margin-top: -10px;" *ngIf="spell != null && spell.concentration && spell.name == effect.name">
+      <span>
+        Concentration spells create an effect with the spell name automatically, this will overwrite it, potentially breaking things.
+      </span>
+    </div>
+
+    <div fxLayout="row" fxLayoutGap="8px" class="auto-row">
+      <span>
+        <mat-checkbox [(ngModel)]="effect.end" (change)="changed.emit();"
+                      matTooltip="Whether the effect duration ticks down at the end of the turn rather than the start.">
+          Ticks on end of turn?
+        </mat-checkbox>
+        <mat-checkbox [(ngModel)]="effect.conc" (change)="changed.emit();">
+          Requires concentration?
+        </mat-checkbox>
+        <mat-checkbox [(ngModel)]="effect.stacking" (change)="changed.emit();"
+                      matTooltip="If another effect with the same name exists, add this effect as a child instead of overwriting it.">
+          Stacking?
+        </mat-checkbox>
+      </span>
     </div>
 
     <div fxLayout="row">
@@ -42,12 +50,12 @@ import {EffectComponent} from '../shared/EffectComponent';
       </mat-form-field>
     </div>
 
-    <div fxLayout="row" fxLayoutGap="8px">
-      <mat-form-field fxFlex>
+    <div fxLayout="row" style="gap: 8px;">
+      <mat-form-field fxFlex style="max-width: calc(50%-4px)">
         <input matInput placeholder="Save As" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.save_as"
                matTooltip="If supplied, saves the added effect as an automation variable. Use this in another IEffect's parent field to set this effect as its parent.">
       </mat-form-field>
-      <mat-form-field fxFlex>
+      <mat-form-field fxFlex style="max-width: calc(50%-4px)">
         <input matInput placeholder="Parent" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.parent"
                matTooltip="If supplied, sets the added effect's parent to the given effect. This must be the same as another IEffect's save_as.">
       </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.ts
@@ -5,7 +5,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-roll-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field fxFlex="1 3 auto">
         <input matInput placeholder="Name" (change)="changed.emit()" [(ngModel)]="effect.name" required
                matTooltip="The result of the roll will be saved to an automation variable with this name.">
@@ -14,13 +14,15 @@ import {EffectComponent} from '../shared/EffectComponent';
         <input matInput placeholder="Dice" (change)="changed.emit()" [(ngModel)]="effect.dice" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
-      <mat-checkbox [(ngModel)]="effect.hidden" (change)="changed.emit()"
-                    matTooltip="If checked, the roll won't display in the automation's Meta field or apply bonuses from the -d argument.">
-        Hidden
-      </mat-checkbox>
+      <span>
+        <mat-checkbox [(ngModel)]="effect.hidden" (change)="changed.emit()"
+                      matTooltip="If checked, the roll won't display in the automation's Meta field or apply bonuses from the -d argument.">
+          Hidden
+        </mat-checkbox>
+      </span>
     </div>
 
-    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+    <div fxLayout="column" fxLayout.gt-xs="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
       <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip

--- a/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.ts
@@ -5,7 +5,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-save-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field>
         <mat-label>Save Stat</mat-label>
         <mat-select [(value)]="effect.stat" (selectionChange)="changed.emit()">

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
@@ -8,7 +8,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-spell-effect',
   template: `
-    <div>
+    <div class="auto-row">
       <span>Cast </span>
 
       <mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/target-effect/target-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/target-effect/target-effect.component.ts
@@ -9,7 +9,7 @@ type TargetSortType = 'user' | 'hp_asc' | 'hp_desc';
 @Component({
   selector: 'avr-target-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="6px">
+    <div fxLayout="row" fxLayoutGap="6px" class="auto-row">
       <mat-form-field>
         <mat-label>Target</mat-label>
         <mat-select [(value)]="selectedTarget" (selectionChange)="onTargetSelectChange($event)">

--- a/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/temphp-effect/temphp-effect.component.ts
@@ -5,13 +5,13 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-temphp-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field fxFlex>
         <input matInput placeholder="Amount" (change)="changed.emit()" [(ngModel)]="effect.amount" required>
         <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">{{"{ }"}}</span>
       </mat-form-field>
     </div>
-    <div fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
+    <div fxLayout="column" fxLayout.gt-xs="row" fxLayoutGap="8px" fxLayoutAlign="left center" *ngIf="spell != null">
       <avr-higher-level fxFlex [parent]="effect" [spell]="spell" (changed)="changed.emit()"></avr-higher-level>
       <mat-checkbox [(ngModel)]="effect.cantripScale" (change)="changed.emit()">
         Scales like Cantrip

--- a/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.ts
@@ -5,7 +5,7 @@ import {EffectComponent} from '../shared/EffectComponent';
 @Component({
   selector: 'avr-variable-effect',
   template: `
-    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
+    <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
       <mat-form-field fxFlex="1 3 auto">
         <input matInput placeholder="Name" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.name" required>
       </mat-form-field>

--- a/src/app/themes/theme-picker/theme-picker.component.scss
+++ b/src/app/themes/theme-picker/theme-picker.component.scss
@@ -20,7 +20,7 @@ $theme-picker-accent-stripe-size: 6px;
     position: relative;
     width: $theme-picker-swatch-size;
     height: $theme-picker-swatch-size;
-    margin: ($theme-picker-grid-cell-size - $theme-picker-swatch-size) / 2;
+    margin: calc(($theme-picker-grid-cell-size - $theme-picker-swatch-size) / 2);
     border-radius: 50%;
     overflow: hidden;
 


### PR DESCRIPTION
### Summary
This PR makes a wide variety of changes to the dashboard to make it more accessible for Mobile/Tablet users.

Including (but probably not limited to, I made a large portion of these changes in December):
- A lot of changes to the various pages to ensure they properly responds to changes in viewport width, including but probably not limited to:
- - Workshop Collections
- - Character Page
- - Automation Editor
- - Homebrew Editors
- Making the dashboard sidebar on mobile auto close when you click the links
- Added a 'Toggle Code Versions' to the workshop collectable editor
- Hid the embed displays for Tomes and Packs on small displays
- Ensured the Gvar/Uvar/Alias/Snippet buttons and names were always visible by making the columns sticky
- Made the buttons/description for characters on the characters page always display when on tablet or smaller display
- Added a warning if the user tries to make an ieffect with the same name as the spell and the spell is concentration

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
