### PR TITLE
Jokeen/2022w29

### DIFF
--- a/src/app/shared/automation-editor/utils.ts
+++ b/src/app/shared/automation-editor/utils.ts
@@ -211,14 +211,18 @@ export class AutomationTreeBuilder {
     },
     check(effect: AbilityCheck): AutomationTreeNode[] {
       if (effect.dc != null) {
+        effect.success = effect.success ?? []
+        effect.fail = effect.fail ?? []
         return [
-          new AutomationTreeNode('Success', undefined, undefined, this.effectsToNodes(effect.success ?? [])),
-          new AutomationTreeNode('Fail', undefined, undefined, this.effectsToNodes(effect.fail ?? []))
+          new AutomationTreeNode('Success', undefined, undefined, this.effectsToNodes(effect.success)),
+          new AutomationTreeNode('Fail', undefined, undefined, this.effectsToNodes(effect.fail))
         ];
       } else if (effect.contestAbility != null) {
+        effect.success = effect.success ?? []
+        effect.fail = effect.fail ?? []
         return [
-          new AutomationTreeNode('Target Wins', undefined, undefined, this.effectsToNodes(effect.success ?? [])),
-          new AutomationTreeNode('Caster Wins', undefined, undefined, this.effectsToNodes(effect.fail ?? []))
+          new AutomationTreeNode('Target Wins', undefined, undefined, this.effectsToNodes(effect.success)),
+          new AutomationTreeNode('Caster Wins', undefined, undefined, this.effectsToNodes(effect.fail))
         ];
       }
       return [];

--- a/src/app/shared/automation-editor/utils.ts
+++ b/src/app/shared/automation-editor/utils.ts
@@ -212,13 +212,13 @@ export class AutomationTreeBuilder {
     check(effect: AbilityCheck): AutomationTreeNode[] {
       if (effect.dc != null) {
         return [
-          new AutomationTreeNode('Success', undefined, undefined, this.effectsToNodes(effect.success)),
-          new AutomationTreeNode('Fail', undefined, undefined, this.effectsToNodes(effect.fail))
+          new AutomationTreeNode('Success', undefined, undefined, this.effectsToNodes(effect.success ?? [])),
+          new AutomationTreeNode('Fail', undefined, undefined, this.effectsToNodes(effect.fail ?? []))
         ];
       } else if (effect.contestAbility != null) {
         return [
-          new AutomationTreeNode('Target Wins', undefined, undefined, this.effectsToNodes(effect.success)),
-          new AutomationTreeNode('Caster Wins', undefined, undefined, this.effectsToNodes(effect.fail))
+          new AutomationTreeNode('Target Wins', undefined, undefined, this.effectsToNodes(effect.success ?? [])),
+          new AutomationTreeNode('Caster Wins', undefined, undefined, this.effectsToNodes(effect.fail ?? []))
         ];
       }
       return [];


### PR DESCRIPTION
### Summary
Ensures that AbilityCheck nodes always displays and works correctly even if the user didn't provide either Fail or Success on a contest/DC'd check.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
