### PR TITLE
Jokeen/2022w35

### DIFF
--- a/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/roll-effect/roll-effect.component.html
@@ -20,12 +20,22 @@
 </div>
 
 <p class="auto-label">Additional Options</p>
-<div>
-  <mat-checkbox [(ngModel)]="effect.hidden"
-                (change)="changed.emit()"
-                matTooltip="If checked, the roll won't display in the automation's Meta field or apply bonuses from the -d argument.">
-    Hidden
-  </mat-checkbox>
+<div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
+  <div fxFlex="1 4 auto" fxLayoutAlign="center center">
+    <mat-checkbox [(ngModel)]="effect.hidden"
+                  (change)="changed.emit()"
+                  matTooltip="If checked, the roll won't display in the automation's Meta field or apply bonuses from the -d argument.">
+      Hidden
+    </mat-checkbox>
+  </div>
+  <mat-form-field fxFlex="4 1 auto">
+    <input matInput
+           placeholder="Display Name"
+           (change)="changed.emit()"
+           [(ngModel)]="effect.displayName"
+           matTooltip="The name to display in the Meta field. If left blank, will use the saved name."
+           class="text-monospace">
+  </mat-form-field>
 </div>
 
 <div *ngIf="spell">

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.html
@@ -71,3 +71,15 @@
     </mat-icon>
   </mat-form-field>
 </div>
+
+
+<div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left baseline">
+  <mat-form-field fxFlex>
+    <input matInput
+           placeholder="Parent"
+           class="text-monospace"
+           (change)="changed.emit()"
+           [(ngModel)]="effect.parent"
+           matTooltip="If supplied, sets the added effect's parent to the given effect. This must be the same as another IEffect's save_as.">
+  </mat-form-field>
+</div>

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
@@ -32,6 +32,7 @@ export class SpellEffectComponent extends EffectComponent<CastSpell> implements 
       this.effect.dc = undefined;
       this.effect.attackBonus = undefined;
       this.effect.castingMod = undefined;
+      this.effect.parent = undefined
     }
   }
 

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.ts
@@ -32,7 +32,6 @@ export class SpellEffectComponent extends EffectComponent<CastSpell> implements 
       this.effect.dc = undefined;
       this.effect.attackBonus = undefined;
       this.effect.castingMod = undefined;
-      this.effect.parent = undefined
     }
   }
 

--- a/src/app/shared/automation-editor/types.ts
+++ b/src/app/shared/automation-editor/types.ts
@@ -130,6 +130,7 @@ export interface Roll extends AutomationEffect {
   higher?: HigherLevels;
   cantripScale?: boolean;
   hidden?: boolean;
+  displayName?: string;
 }
 
 export interface Text extends AutomationEffect {

--- a/src/app/shared/automation-editor/types.ts
+++ b/src/app/shared/automation-editor/types.ts
@@ -178,6 +178,7 @@ export interface CastSpell extends AutomationEffect {
   dc?: IntExpression;
   attackBonus?: IntExpression;
   castingMod?: IntExpression;
+  parent?: string;
 }
 
 export interface AbilityCheck extends AutomationEffect {


### PR DESCRIPTION
### Summary

Adds support for the new `displayName` key in Roll effects and `parent` key in Cast a Spell effects.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
