### PR TITLE
Jokeen/2022w40

### DIFF
--- a/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.html
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.html
@@ -34,8 +34,23 @@
       Need some references? You can <a href="https://avrae.readthedocs.io/en/stable/aliasing/api.html" target="_blank">
       find the Draconic documentation here</a>.
     </p>
-    <mat-slide-toggle (change)="toggleWordWrap()">Word Wrap</mat-slide-toggle>
-    <mat-slide-toggle *ngIf="mobile" (change)="toggleCodeVersions()">Code Versions</mat-slide-toggle>
+    <!-- Various Controls for the Editor-->
+    <div class="editor-controls">
+      <div>
+        <mat-slide-toggle (change)="toggleWordWrap()">Word Wrap</mat-slide-toggle>
+        <mat-slide-toggle *ngIf="mobile" (change)="toggleCodeVersions()" style="margin-left:8px">Code Versions</mat-slide-toggle>
+      </div>
+      <div *ngIf="(selectedCodeVersion && !selectedCodeVersion.is_current) || creatingNewCodeVersion">
+        <!-- buttons: set active code version or save new code version -->
+        <button mat-raised-button *ngIf="selectedCodeVersion && !selectedCodeVersion.is_current" color="accent"
+                (click)="onSetCurrentAsActive()">
+          Set Version {{selectedCodeVersion.version}} as Active Code Version
+        </button>
+        <button mat-raised-button *ngIf="creatingNewCodeVersion" color="accent" (click)="onSaveNewCodeVersion()">
+          Save New Code Version
+        </button>
+      </div>
+    </div>
     <div class="code-versions-container ignore-theme">
       <!-- code editor: display selected, edit new version, or placeholder if nothing selected -->
       <div class="code-editor">
@@ -73,16 +88,9 @@
           </mat-list-item>
         </mat-action-list>
       </div>
+
     </div> <!-- </code-versions-container> -->
-    <!-- buttons: set active code version or save new code version -->
-    <button mat-raised-button *ngIf="selectedCodeVersion && !selectedCodeVersion.is_current" color="accent"
-            (click)="onSetCurrentAsActive()" class="code-versions-button">
-      Set Version {{selectedCodeVersion.version}} as Active Code Version
-    </button>
-    <button mat-raised-button *ngIf="creatingNewCodeVersion" color="accent" (click)="onSaveNewCodeVersion()"
-            class="spaced-button">
-      Save New Code Version
-    </button>
+
   </div>
 
   <mat-divider></mat-divider>

--- a/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.scss
+++ b/src/app/dashboard/workshop/collection-edit/collectable-edit-dialog/collectable-edit-dialog.component.scss
@@ -65,3 +65,24 @@ mat-form-field {
     display: block;
   }
 }
+
+.editor-controls {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  min-height: 45px;
+}
+
+.editor-controls div {
+  gap: 8px;
+  display: flex;
+}
+
+@media (max-width: 600px) {
+  .editor-controls {
+    justify-content: center;
+  }
+}

--- a/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/attack-effect/attack-effect.component.html
@@ -17,7 +17,7 @@
            class="text-monospace"
            (change)="changed.emit()"
            [(ngModel)]="effect.attackBonus">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>
@@ -46,7 +46,7 @@
 2 for Elven Accuracy
 -1 for Disadvantage"
            [matTooltipClass]="'adv-tooltip'">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/check-effect/check-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/check-effect/check-effect.component.html
@@ -25,7 +25,7 @@
 <div *ngIf="checkType === 'dc'">
   <mat-form-field class="is-fullwidth">
     <input matInput required placeholder="DC" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.dc">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/condition-effect/condition-effect.component.html
@@ -9,7 +9,7 @@
   <mat-form-field class="is-fullwidth">
     <input matInput placeholder="Condition" class="text-monospace" (change)="changed.emit()"
            [(ngModel)]="effect.condition" required>
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.html
@@ -34,7 +34,7 @@
                [(ngModel)]="effect.counter.slot"
                required>
         <mat-icon matSuffix
-                  matTooltip="IntExpression - variables and functions allowed, braces optional">
+                  matTooltip="IntExpression - variables and functions allowed">
           calculate
         </mat-icon>
       </mat-form-field>
@@ -71,7 +71,7 @@
            (change)="changed.emit()"
            [(ngModel)]="effect.amount"
            required>
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/counter-effect/counter-effect.component.html
@@ -70,7 +70,8 @@
            class="text-monospace"
            (change)="changed.emit()"
            [(ngModel)]="effect.amount"
-           required>
+           required
+           matTooltip="If negative, will add charges instead of using them">
     <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.css
@@ -1,3 +1,6 @@
 .is-italics {
   font-style: italic;
 }
+.move-up {
+  margin-right: 24px;
+}

--- a/src/app/shared/automation-editor/effect-editor/effect-editor.component.html
+++ b/src/app/shared/automation-editor/effect-editor/effect-editor.component.html
@@ -4,7 +4,7 @@
   </span>
   <span class="toolbar-spacer"></span>
   <span>
-    <button mat-icon-button matTooltip="Move Up" *ngIf="!isFirst" (click)="moveUp()">
+    <button mat-icon-button matTooltip="Move Up" *ngIf="!isFirst" [ngClass]="{'move-up': isLast}" (click)="moveUp()">
       <mat-icon aria-label="Move Up">arrow_upward</mat-icon>
     </button>
     <button mat-icon-button matTooltip="Move Down" *ngIf="!isLast" (click)="moveDown()">

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect-effect.component.html
@@ -15,7 +15,7 @@
            [(ngModel)]="effect.duration"
            required
            matTooltip="Use -1 for infinite duration.">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">calculate
     </mat-icon>
   </mat-form-field>
   <mat-form-field fxFlex="2 1 auto">

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.css
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.css
@@ -20,3 +20,7 @@
 .button-style-4 {
   background: rgb(216, 60, 62);
 }
+
+::ng-deep .adv-tooltip {
+  white-space:  pre-line !important;
+}

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
@@ -28,7 +28,7 @@
            (change)="changed.emit()"
            [(ngModel)]="durationWrapper"
            matTooltip="The duration, in rounds. Leave blank for infinite duration.">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
@@ -27,7 +27,13 @@
            placeholder="Indefinite"
            (change)="changed.emit()"
            [(ngModel)]="durationWrapper"
-           matTooltip="The duration, in rounds. Leave blank for infinite duration.">
+           matTooltip="The duration, in rounds. Leave blank for infinite duration.
+
+1 Min  - 10
+1 Hour - 600
+1 Day  - 14400
+1 Year - 5256000"
+           [matTooltipClass]="'adv-tooltip'">
     <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
@@ -84,7 +90,7 @@
           <!-- intexpression or annotatedstring -->
           <mat-icon matSuffix
                     *ngIf="isValueIntExpression(passiveEffectGroup)"
-                    matTooltip="IntExpression - variables and functions allowed, braces optional">
+                    matTooltip="IntExpression - variables and functions allowed">
             calculate
           </mat-icon>
           <span matSuffix
@@ -202,7 +208,7 @@
           <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
             <mat-form-field fxFlex>
               <input matInput formControlName="defaultDc" placeholder="DC" class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -212,7 +218,7 @@
                      formControlName="defaultAttackBonus"
                      placeholder="Spell Attack Bonus"
                      class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -222,7 +228,7 @@
                      formControlName="defaultCastingMod"
                      placeholder="Spellcasting Modifier"
                      class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -305,7 +311,7 @@
             <mat-form-field fxFlex="4 1 auto" *ngIf="isCustomButtonStyle(buttonGroup)">
               <mat-label>Custom Expression</mat-label>
               <input matInput formControlName="customStyle">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -323,7 +329,7 @@
           <div fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center" class="auto-row">
             <mat-form-field fxFlex>
               <input matInput formControlName="defaultDc" placeholder="DC" class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -333,7 +339,7 @@
                      formControlName="defaultAttackBonus"
                      placeholder="Spell Attack Bonus"
                      class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>
@@ -343,7 +349,7 @@
                      formControlName="defaultCastingMod"
                      placeholder="Spellcasting Modifier"
                      class="text-monospace">
-              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+              <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
                 calculate
               </mat-icon>
             </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/save-effect/save-effect.component.html
@@ -28,7 +28,7 @@
   </mat-checkbox>
   <mat-form-field fxFlex="grow" *ngIf="custom">
     <input matInput placeholder="DC" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.dc">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/spell-effect/spell-effect.component.html
@@ -44,7 +44,7 @@
 <div *ngIf="custom" fxLayout="row" fxLayoutGap="4px" fxLayoutAlign="left center">
   <mat-form-field fxFlex>
     <input matInput placeholder="DC" class="text-monospace" (change)="changed.emit()" [(ngModel)]="effect.dc">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>
@@ -55,7 +55,7 @@
            class="text-monospace"
            (change)="changed.emit()"
            [(ngModel)]="effect.attackBonus">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>
@@ -66,7 +66,7 @@
            class="text-monospace"
            (change)="changed.emit()"
            [(ngModel)]="effect.castingMod">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">
       calculate
     </mat-icon>
   </mat-form-field>

--- a/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/variable-effect/variable-effect.component.html
@@ -23,7 +23,7 @@
            (change)="changed.emit()"
            [(ngModel)]="effect.value"
            required>
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">calculate
     </mat-icon>
   </mat-form-field>
 </div>
@@ -37,7 +37,7 @@
            class="text-monospace"
            (change)="changed.emit()"
            [(ngModel)]="effect.onError">
-    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed, braces optional">calculate
+    <mat-icon matSuffix matTooltip="IntExpression - variables and functions allowed">calculate
     </mat-icon>
   </mat-form-field>
 </div>

--- a/src/app/shared/automation-editor/new-effect-button.component.ts
+++ b/src/app/shared/automation-editor/new-effect-button.component.ts
@@ -369,7 +369,7 @@ export class NewEffectButtonComponent implements OnInit {
               {type: 'damage', damage: '{damage}'} as Damage
             ],
             success: [
-              {type: 'damage', damage: '({damage}/2)'} as Damage
+              {type: 'damage', damage: '({damage})/2'} as Damage
             ]
           } as Save
         ]


### PR DESCRIPTION
### Summary

- Ensures the "Move Up" button on the automation editor stays in the same place even if the "Move Down" button isn't present
- Added a tooltip to the ``duration`` key in IEffect effect to provide a helpful reference to common ieffect durations
- Added a tooltip to the Use Counter effect to note that negative numbers add uses
- Removed the mention of braces being optional from the IntExpression tooltip, as it was causing confusion
- Fixed the location of parentheses for the Save for Half Damage preset in automation
- Updated the location of the Save Code Version/Create Code Version buttons in the workshop editor to reduce confusion and make them easier to notice ![New Button Location](https://cdn.discordapp.com/attachments/755143872321028206/1022764476367376444/chrome_OMPRZkz2Lz.gif)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
