### PR TITLE
Add support for text.title and mark ieffect2.name as annotated

### DIFF
--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
@@ -13,6 +13,9 @@
       Concentration spells create an effect with the spell name automatically. This will overwrite it, potentially
       creating issues.
     </mat-error>
+    <span matSuffix matTooltip="AnnotatedString - variables and functions allowed in braces">
+      {{"{ }"}}
+    </span>
   </mat-form-field>
 </div>
 

--- a/src/app/shared/automation-editor/effect-editor/text-effect/text-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/text-effect/text-effect.component.html
@@ -23,6 +23,16 @@
   </span>
 </div>
 
+<div>
+  <mat-form-field class="is-fullwidth">
+    <textarea matInput
+              placeholder="Title"
+              (change)="changed.emit()"
+              [(ngModel)]="effect.title">
+    </textarea>
+  </mat-form-field>
+</div>
+
 <div *ngIf="textType === 'text'">
   <mat-form-field class="is-fullwidth">
     <textarea matInput

--- a/src/app/shared/automation-editor/types.ts
+++ b/src/app/shared/automation-editor/types.ts
@@ -105,7 +105,7 @@ export interface ButtonInteraction {
 
 export interface IEffect extends AutomationEffect {
   type: 'ieffect2';
-  name: string;
+  name: AnnotatedString;
   duration?: number | IntExpression;
   effects?: PassiveEffects;
   attacks?: AttackInteraction[];
@@ -136,6 +136,7 @@ export interface Roll extends AutomationEffect {
 export interface Text extends AutomationEffect {
   type: 'text';
   text: AnnotatedString | AbilityReference;
+  title?: string;
 }
 
 export interface SetVariable extends AutomationEffect {


### PR DESCRIPTION
### Summary
Adds a field for text.title and marks ieffect2.name as annotated

This PR supports https://github.com/avrae/avrae/pull/1921

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
