### PR TITLE
feat: add ieffect hidden checkbox

### DIFF
--- a/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
+++ b/src/app/shared/automation-editor/effect-editor/ieffect-effect/ieffect2-effect.component.html
@@ -53,6 +53,11 @@
                 matTooltip="Should this effect tick down on the casters turn, or the targets turn.">
     Tick on Caster
   </mat-checkbox>
+  <mat-checkbox [(ngModel)]="effect.hidden"
+                (change)="changed.emit();"
+                matTooltip="Should this effect's stat modifiers and description be hidden from display in combat display.">
+    Hidden
+  </mat-checkbox>
   <mat-checkbox [(ngModel)]="effect.conc" (change)="changed.emit();">
     Requires concentration
   </mat-checkbox>

--- a/src/app/shared/automation-editor/types.ts
+++ b/src/app/shared/automation-editor/types.ts
@@ -120,6 +120,7 @@ export interface IEffect extends AutomationEffect {
   parent?: string;
   target_self?: boolean;
   tick_on_caster?: boolean;
+  hidden?: boolean;
 }
 
 export interface RemoveIEffect extends AutomationEffect {


### PR DESCRIPTION
### Summary
Adds checkbox to automation dashboard, which chooses whether or not to make ieffect desc and stat mods hidden in combat.

Depends on [PR#2213](https://github.com/avrae/avrae/pull/2213) on main avrae repo: https://github.com/avrae/avrae/pull/2213

### Checklist
#### PR Type
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
