### PR TITLE
Change creature homebrew link to Bestiary Builder

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -53,7 +53,7 @@
         <div class="nav-panel-body">
           <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/homebrew/items">Items</a>
           <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" routerLink="/dashboard/homebrew/spells">Spells</a>
-          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" href="https://critterdb.com/#/index" target="_blank" rel="noopener noreferrer">Creatures
+          <a mat-list-item (click)="(small || mobile) && sidenav.toggle()" href="https://bestiarybuilder.com" target="_blank" rel="noopener noreferrer">Creatures
             <mat-icon class="icon-in-panel">launch</mat-icon>
           </a>
         </div>


### PR DESCRIPTION
CritterDB hasn't received updates in years, and is not designed for Avrae. BB is. So changing the link to the improved project makes sense.


