### PR TITLE
feat: added gvar script-writtable related display information to ui

### DIFF
--- a/src/app/dashboard/gvars/gvar-list/gvar-list.component.css
+++ b/src/app/dashboard/gvars/gvar-list/gvar-list.component.css
@@ -9,7 +9,7 @@
 pre {
   white-space: pre-wrap;
   max-height: 200px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 @media only screen and (max-width: 840px) {
@@ -39,4 +39,9 @@ td.mat-cell, td.mat-footer-cell, th.mat-header-cell {
 
 th {
   min-width: 100px;
+}
+
+.scripting-col {
+  text-align: center;
+  vertical-align: middle;
 }

--- a/src/app/dashboard/gvars/gvar-list/gvar-list.component.html
+++ b/src/app/dashboard/gvars/gvar-list/gvar-list.component.html
@@ -13,6 +13,15 @@
     <td mat-footer-cell *matFooterCellDef></td>
   </ng-container>
 
+  <ng-container matColumnDef="scripting">
+    <th mat-header-cell *matHeaderCellDef class="scripting-col">Script-writable</th>
+    <td mat-cell *matCellDef="let gvar" class="scripting-col">
+      <mat-icon *ngIf="gvar.script_writable" aria-label="Script-writable">check</mat-icon>
+      <span *ngIf="!gvar.script_writable" aria-label="Not script-writable">—</span>
+    </td>
+    <td mat-footer-cell *matFooterCellDef></td>
+  </ng-container>
+
   <ng-container matColumnDef="buttons" stickyEnd>
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let gvar">

--- a/src/app/dashboard/gvars/gvar-list/gvar-list.component.ts
+++ b/src/app/dashboard/gvars/gvar-list/gvar-list.component.ts
@@ -17,7 +17,7 @@ export class GvarListComponent implements OnInit {
   @Input() data: GlobalVar[];
   @Input() owned: boolean;
 
-  columnsToDisplay: string[] = ['name', 'value', 'buttons'];
+  columnsToDisplay: string[] = ['name', 'value', 'scripting', 'buttons'];
 
   constructor(private dialog: MatDialog, private snackBar: MatSnackBar, private gvarService: GvarService) {
   }

--- a/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.html
+++ b/src/app/dashboard/gvars/gvar-lookup/gvar-lookup.component.html
@@ -10,6 +10,9 @@
   <p>
     <i>Owned by: {{activeGvar.owner_name}}</i>
   </p>
+  <p>
+    <i>Script-writable: {{activeGvar.script_writable ? 'yes' : 'no'}}</i>
+  </p>
 
   <mat-divider></mat-divider>
 

--- a/src/app/schemas/Customization.ts
+++ b/src/app/schemas/Customization.ts
@@ -35,4 +35,5 @@ export class GlobalVar {
   owner_name: string;
   value: string;
   editors: string[];
+  script_writable: boolean;
 }


### PR DESCRIPTION
### Summary
Surfaces the new gvar `script_writable` flag in the gvar dashboard. The Avrae bot now lets aliases
write global variables via `set_gvar`/`create_gvar`, gated by a per-gvar `script_writable` flag (set
with the `!gvar scripting` command). This PR makes that flag **visible** on the website:

- **Owned / Editable lists** — a new centered **"Script-writable"** column showing `✓` (writable) or
  `—` (not).
- **Lookup view** — a **"Script-writable: yes/no"** line under the owner.
- **Model** — added `script_writable: boolean` to the `GlobalVar` schema so it's read from the API.

This is **display-only**. Toggling the flag is intentionally *not* added here — it remains the
owner-only `!gvar scripting <id>` Discord command. (A dashboard toggle would be a follow-up and also
requires an avrae-service change, since the gvar create/update endpoints don't currently accept the
field.)

No avrae-service change is needed for this PR: the gvar API already returns the full document, so the
field is available to read; and the value-edit endpoint only `$set`s `value`, so editing a value from
the dashboard leaves `script_writable` untouched.

Also includes a small adjacent cleanup in the same component: the value column's `<pre>` was changed
from `overflow-y: scroll` to `overflow-y: auto`, so short values no longer render a permanent scrollbar
square next to the new column (the scrollbar still appears for tall values).

**Depends on** the bot-repo change that adds and serves the `script_writable` field. [Specific PR](https://github.com/avrae/avrae/pull/2271)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
